### PR TITLE
Add ideas page with waterfall layout

### DIFF
--- a/ideas.html
+++ b/ideas.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>灵感列表</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>
+    .masonry { column-count: 3; column-gap: 1rem; }
+    @media (max-width: 1024px) { .masonry { column-count: 2; } }
+    @media (max-width: 640px) { .masonry { column-count: 1; } }
+    .masonry-item { break-inside: avoid; margin-bottom: 1rem; }
+  </style>
+</head>
+<body class="bg-gradient-to-br from-slate-50 to-slate-200 min-h-screen font-sans">
+  <nav class="fixed top-0 left-0 h-screen w-[72px] bg-white border-r shadow flex flex-col items-center py-4">
+    <div class="sidebar-items flex flex-col items-center gap-y-6 h-full w-full">
+      <a href="/" aria-label="主页" class="sidebar-link">
+        <svg viewBox="0 0 24 24" fill="currentColor" class="w-6 h-6">
+          <path d="M7.54 23.15q-.2-2.05.26-3.93L9 14.04a7 7 0 0 1-.35-2.07c0-1.68.81-2.88 2.09-2.88.88 0 1.53.62 1.53 1.8q0 .57-.23 1.28l-.52 1.72q-.15.5-.15.92c0 1.2.91 1.87 2.08 1.87 2.09 0 3.57-2.16 3.57-4.96 0-3.12-2.04-5.12-5.05-5.12-3.36 0-5.49 2.19-5.49 5.24 0 1.22.38 2.36 1.11 3.14-.24.41-.5.48-.88.48-1.2 0-2.34-1.69-2.34-4 0-4 3.2-7.17 7.68-7.17 4.7 0 7.66 3.29 7.66 7.33s-2.88 7.15-5.98 7.15a3.8 3.8 0 0 1-3.06-1.48l-.62 2.5a11 11 0 0 1-1.62 3.67A11.98 11.98 0 0 0 24 12a11.99 11.99 0 1 0-24 0 12 12 0 0 0 7.54 11.15"/>
+        </svg>
+      </a>
+      <a href="/" aria-label="首页" class="sidebar-link" id="homeBtn">
+        <svg viewBox="0 0 24 24" fill="currentColor" class="w-6 h-6">
+          <path d="M4.6 22.73A107 107 0 0 0 11 23h2.22c2.43-.04 4.6-.16 6.18-.27A3.9 3.9 0 0 0 23 18.8v-8.46a4 4 0 0 0-1.34-3L14.4.93a3.63 3.63 0 0 0-4.82 0L2.34 7.36A4 4 0 0 0 1 10.35v8.46a3.9 3.9 0 0 0 3.6 3.92M13.08 2.4l7.25 6.44a2 2 0 0 1 .67 1.5v8.46a1.9 1.9 0 0 1-1.74 1.92q-1.39.11-3.26.19V16a4 4 0 0 0-8 0v4.92q-1.87-.08-3.26-.19A1.9 1.9 0 0 1 3 18.81v-8.46a2 2 0 0 1 .67-1.5l7.25-6.44a1.63 1.63 0 0 1 2.16 0M13.12 21h-2.24a1 1 0 0 1-.88-1v-4a2 2 0 1 1 4 0v4a1 1 0 0 1-.88 1" />
+        </svg>
+      </a>
+      <a href="/ideas" aria-label="探索" id="idealBtn" class="sidebar-link">
+        <svg viewBox="0 0 24 24" fill="currentColor" class="w-6 h-6">
+          <path d="M12 14a2 2 0 1 0 0-4 2 2 0 0 0 0 4M9.42 7.24a3 3 0 0 0-2.18 2.18L5.7 15.57a2.25 2.25 0 0 0 2.73 2.73l6.15-1.54a3 3 0 0 0 2.18-2.18l1.54-6.15a2.25 2.25 0 0 0-2.73-2.73zm6.94.7-1.54 6.15a1 1 0 0 1-.73.73l-6.15 1.54a.25.25 0 0 1-.3-.3L9.18 9.9a1 1 0 0 1 .73-.73l6.15-1.54a.25.25 0 0 1 .3.3M12 24a12 12 0 1 0 0-24 12 12 0 0 0 0 24M2 12a10 10 0 1 1 20 0 10 10 0 0 1-20 0" />
+        </svg>
+      </a>
+    </div>
+  </nav>
+  <div id="content" class="ml-[72px]">
+    <header class="py-6 text-center">
+      <h1 class="text-3xl font-bold tracking-tight text-slate-800">灵感列表</h1>
+    </header>
+    <main class="px-4 max-w-screen-xl mx-auto">
+      <div class="masonry" id="ideas"></div>
+    </main>
+  </div>
+<script>
+const container = document.getElementById('ideas');
+function getParagraphs(jsonWx) {
+  if (Array.isArray(jsonWx)) return jsonWx;
+  if (jsonWx && Array.isArray(jsonWx.paragraphs)) return jsonWx.paragraphs;
+  if (jsonWx && Array.isArray(jsonWx.data)) return jsonWx.data;
+  if (jsonWx && Array.isArray(jsonWx.items)) return jsonWx.items;
+  return [];
+}
+function pickRandom(arr) { return arr[Math.floor(Math.random()*arr.length)]; }
+async function loadIdeas() {
+  try {
+    const res = await fetch('/api/wx');
+    if (!res.ok) throw new Error('fetch fail');
+    const data = await res.json();
+    const items = [];
+    for (const [title, info] of Object.entries(data)) {
+      const paragraphs = getParagraphs(info.jsonWx || []);
+      const imgs = Array.isArray(info.images) ? info.images : [];
+      paragraphs.forEach(p => {
+        const img = imgs.length ? `/img?url=${pickRandom(imgs)}` : '';
+        items.push({ title, desc: p, img });
+      });
+    }
+    items.forEach(({title, desc, img}) => {
+      const div = document.createElement('div');
+      div.className = 'masonry-item p-4 bg-white rounded-xl shadow hover:shadow-lg transition flex flex-col gap-2';
+      if (img) {
+        const im = document.createElement('img');
+        im.src = img;
+        im.alt = title;
+        im.loading = 'lazy';
+        im.className = 'w-full rounded object-cover';
+        div.appendChild(im);
+      }
+      div.insertAdjacentHTML('beforeend', `<h2 class="text-lg font-semibold text-slate-900">${title}</h2><p class="text-sm text-gray-600 leading-relaxed">${desc}</p>`);
+      container.appendChild(div);
+    });
+  } catch(e){
+    console.error('加载失败', e);
+  }
+}
+document.addEventListener('DOMContentLoaded', loadIdeas);
+</script>
+</body>
+</html>

--- a/server.ts
+++ b/server.ts
@@ -7,6 +7,7 @@ import cheerio from "npm:cheerio@1.0.0-rc.12";
 const PORT = Number(Deno.env.get("PORT") ?? 8000);           // Deno Deploy 会自动注入
 const __dirname = dirname(fromFileUrl(import.meta.url));
 const indexHtml = await Deno.readTextFile(join(__dirname, "main.html"));
+const ideasHtml = await Deno.readTextFile(join(__dirname, "ideas.html"));
 
 // 微信文章列表
 const urls = [
@@ -139,6 +140,13 @@ async function handler(req: Request): Promise<Response> {
     const imgUrl = searchParams.get("url");
     if (!imgUrl) return new Response("missing url", { status: 400 });
     return await proxyImage(imgUrl);
+  }
+
+  // /ideas —— 灵感瀑布流页面
+  if (pathname === "/ideas") {
+    return new Response(ideasHtml, {
+      headers: { "Content-Type": "text/html; charset=utf-8" },
+    });
   }
 
   // 其他路径 —— 静态首页


### PR DESCRIPTION
## Summary
- add `ideas.html` for showing paragraphs as inspiration cards
- support `/ideas` route in server

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6853ffb56bc0832eb091a94c550c725b