### PR TITLE
Implement browser cache update notification

### DIFF
--- a/ideas.html
+++ b/ideas.html
@@ -77,6 +77,15 @@
         margin-left: 0;
         margin-bottom: 72px;
       }
+      .notify-dot {
+        position: absolute;
+        top: 4px;
+        right: 4px;
+        width: 0.5rem;
+        height: 0.5rem;
+        background-color: #ef4444;
+        border-radius: 9999px;
+      }
     </style>
   </head>
   <body class="bg-gradient-to-br from-slate-50 to-slate-200 min-h-screen font-sans">
@@ -149,6 +158,25 @@
       const applySettings = document.getElementById('applySettings');
       const columnCountInput = document.getElementById('columnCountInput');
       const perPageInput = document.getElementById('perPageInput');
+
+      const homeLink = document.querySelector('a[aria-label="\u4e3b\u9875"]');
+      let notifyDot = null;
+
+      function showDot() {
+        if (!notifyDot) {
+          notifyDot = document.createElement('span');
+          notifyDot.className = 'notify-dot';
+          homeLink.classList.add('relative');
+          homeLink.appendChild(notifyDot);
+        }
+      }
+
+      function hideDot() {
+        if (notifyDot) {
+          notifyDot.remove();
+          notifyDot = null;
+        }
+      }
 
       const savedCols = parseInt(localStorage.getItem('columnCount')) || 4;
       const savedPerPage = parseInt(localStorage.getItem('perPage')) || 30;
@@ -236,6 +264,17 @@
         return wrapper;
       }
 
+      function buildItems(data) {
+        const items = [];
+        for (const [title, { description, images }] of Object.entries(data)) {
+          const imgSrc = Array.isArray(images) && images.length > 0
+            ? images[Math.floor(Math.random() * images.length)]
+            : null;
+          items.push({ title, description, imgSrc });
+        }
+        return items;
+      }
+
       function renderPage() {
         gallery.innerHTML = '';
         const end = (currentPage + 1) * perPage;
@@ -250,20 +289,38 @@
         }
       }
 
-      async function loadGallery() {
+      function applyData(data) {
+        allItems = buildItems(data);
+        currentPage = 0;
+        renderPage();
+      }
+
+      async function fetchLatest() {
+        const res = await fetch('/api/wx', { headers: { 'x-skip-cache': '1' } });
+        if (!res.ok) throw new Error('Network response was not ok');
+        return await res.json();
+      }
+
+      async function initGallery() {
+        const cachedStr = localStorage.getItem('wxData');
+        let cached;
+        if (cachedStr) {
+          try { cached = JSON.parse(cachedStr); } catch {}
+        }
+        if (cached) {
+          applyData(cached);
+        }
+
         try {
-          const res = await fetch('/api/wx');
-          if (!res.ok) throw new Error('Network response was not ok');
-          const data = await res.json();
-          const items = [];
-          for (const [title, { description, images }] of Object.entries(data)) {
-            const imgSrc = Array.isArray(images) && images.length > 0
-              ? images[Math.floor(Math.random() * images.length)]
-              : null;
-            items.push({ title, description, imgSrc });
+          const latest = await fetchLatest();
+          const latestStr = JSON.stringify(latest);
+          if (!cachedStr) {
+            localStorage.setItem('wxData', latestStr);
+            applyData(latest);
+          } else if (latestStr !== cachedStr) {
+            localStorage.setItem('wxDataNew', latestStr);
+            showDot();
           }
-          allItems = items;
-          renderPage();
         } catch (err) {
           console.error('加载画廊失败:', err);
         }
@@ -297,7 +354,23 @@
         settingsPanel.classList.remove('flex');
       });
 
-      document.addEventListener('DOMContentLoaded', loadGallery);
+      document.addEventListener('DOMContentLoaded', initGallery);
+      homeLink.addEventListener('click', () => {
+        const newStr = localStorage.getItem('wxDataNew');
+        if (newStr) {
+          localStorage.setItem('wxData', newStr);
+          localStorage.removeItem('wxDataNew');
+          hideDot();
+          try {
+            applyData(JSON.parse(newStr));
+          } catch (e) {}
+        }
+      });
+      if ('serviceWorker' in navigator) {
+        window.addEventListener('load', () => {
+          navigator.serviceWorker.register('/sw.js').catch(console.error);
+        });
+      }
     </script>
 </div>
   </body>

--- a/main.html
+++ b/main.html
@@ -77,6 +77,15 @@
         margin-left: 0;
         margin-bottom: 72px;
       }
+      .notify-dot {
+        position: absolute;
+        top: 4px;
+        right: 4px;
+        width: 0.5rem;
+        height: 0.5rem;
+        background-color: #ef4444;
+        border-radius: 9999px;
+      }
     </style>
   </head>
   <body class="bg-gradient-to-br from-slate-50 to-slate-200 min-h-screen font-sans">
@@ -150,6 +159,25 @@
       const columnCountInput = document.getElementById('columnCountInput');
       const perPageInput = document.getElementById('perPageInput');
 
+      const homeLink = document.querySelector('a[aria-label="\u4e3b\u9875"]');
+      let notifyDot = null;
+
+      function showDot() {
+        if (!notifyDot) {
+          notifyDot = document.createElement('span');
+          notifyDot.className = 'notify-dot';
+          homeLink.classList.add('relative');
+          homeLink.appendChild(notifyDot);
+        }
+      }
+
+      function hideDot() {
+        if (notifyDot) {
+          notifyDot.remove();
+          notifyDot = null;
+        }
+      }
+
       const savedCols = parseInt(localStorage.getItem('columnCount')) || 4;
       const savedPerPage = parseInt(localStorage.getItem('perPage')) || 30;
 
@@ -210,6 +238,21 @@
         return img;
       }
 
+      function buildItems(data) {
+        const items = [];
+        for (const [title, { description, images }] of Object.entries(data)) {
+          items.push({
+            type: 'title',
+            html:
+              `<div class="masonry-item p-5 bg-white rounded-2xl shadow hover:shadow-lg transition flex flex-col gap-2">\n  <h2 class="text-xl font-semibold text-slate-900">${title}</h2>\n  <p class="text-sm text-gray-600 leading-relaxed">${description}</p>\n</div>`
+          });
+          images.forEach((src) => {
+            items.push({ type: 'image', src, alt: title });
+          });
+        }
+        return items;
+      }
+
       function renderPage() {
         gallery.innerHTML = '';
         const end = (currentPage + 1) * perPage;
@@ -228,23 +271,38 @@
         }
       }
 
-      async function loadGallery() {
+      function applyData(data) {
+        allItems = buildItems(data);
+        currentPage = 0;
+        renderPage();
+      }
+
+      async function fetchLatest() {
+        const res = await fetch('/api/wx', { headers: { 'x-skip-cache': '1' } });
+        if (!res.ok) throw new Error('Network response was not ok');
+        return await res.json();
+      }
+
+      async function initGallery() {
+        const cachedStr = localStorage.getItem('wxData');
+        let cached;
+        if (cachedStr) {
+          try { cached = JSON.parse(cachedStr); } catch {}
+        }
+        if (cached) {
+          applyData(cached);
+        }
+
         try {
-          const res = await fetch('/api/wx');
-          if (!res.ok) throw new Error('Network response was not ok');
-          const data = await res.json();
-          const items = [];
-          for (const [title, { description, images }] of Object.entries(data)) {
-            items.push({
-              type: 'title',
-              html: `<div class="masonry-item p-5 bg-white rounded-2xl shadow hover:shadow-lg transition flex flex-col gap-2">\n  <h2 class="text-xl font-semibold text-slate-900">${title}</h2>\n  <p class="text-sm text-gray-600 leading-relaxed">${description}</p>\n</div>`
-            });
-            images.forEach((src) => {
-              items.push({ type: 'image', src, alt: title });
-            });
+          const latest = await fetchLatest();
+          const latestStr = JSON.stringify(latest);
+          if (!cachedStr) {
+            localStorage.setItem('wxData', latestStr);
+            applyData(latest);
+          } else if (latestStr !== cachedStr) {
+            localStorage.setItem('wxDataNew', latestStr);
+            showDot();
           }
-          allItems = items;
-          renderPage();
         } catch (err) {
           console.error('加载画廊失败:', err);
         }
@@ -278,7 +336,23 @@
         settingsPanel.classList.remove('flex');
       });
 
-      document.addEventListener('DOMContentLoaded', loadGallery);
+      document.addEventListener('DOMContentLoaded', initGallery);
+      homeLink.addEventListener('click', () => {
+        const newStr = localStorage.getItem('wxDataNew');
+        if (newStr) {
+          localStorage.setItem('wxData', newStr);
+          localStorage.removeItem('wxDataNew');
+          hideDot();
+          try {
+            applyData(JSON.parse(newStr));
+          } catch (e) {}
+        }
+      });
+      if ('serviceWorker' in navigator) {
+        window.addEventListener('load', () => {
+          navigator.serviceWorker.register('/sw.js').catch(console.error);
+        });
+      }
     </script>
 </div>
   </body>

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,54 @@
+const CACHE_NAME = 'wx-cache-v1';
+
+self.addEventListener('install', event => {
+  self.skipWaiting();
+  event.waitUntil(caches.open(CACHE_NAME));
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(names =>
+      Promise.all(names.filter(n => n !== CACHE_NAME).map(n => caches.delete(n)))
+    )
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', event => {
+  const url = new URL(event.request.url);
+  if (url.pathname === '/api/wx') {
+    if (event.request.headers.get('x-skip-cache')) {
+      event.respondWith(fetchAndCache(event.request));
+    } else {
+      event.respondWith(cacheThenNetwork(event.request));
+    }
+  } else if (url.pathname.startsWith('/img')) {
+    event.respondWith(cacheThenNetwork(event.request));
+  }
+});
+
+async function fetchAndCache(request) {
+  const cache = await caches.open(CACHE_NAME);
+  const res = await fetch(request);
+  if (res.ok) await cache.put('/api/wx', res.clone());
+  return res;
+}
+
+async function cacheThenNetwork(request) {
+  const cache = await caches.open(CACHE_NAME);
+  const cached = await cache.match(request);
+  if (cached) {
+    fetch(request).then(res => {
+      if (res.ok) cache.put(request, res.clone());
+    }).catch(() => {});
+    return cached;
+  }
+  try {
+    const res = await fetch(request);
+    if (res.ok) await cache.put(request, res.clone());
+    return res;
+  } catch (err) {
+    if (cached) return cached;
+    throw err;
+  }
+}


### PR DESCRIPTION
## Summary
- update `sw.js` so fetches with `x-skip-cache` bypass the cache
- add `.notify-dot` style
- cache API results in `localStorage` and show a red dot when updates exist
- refresh cached data when the "主页" icon is clicked

## Testing
- `deno fmt --check *.ts *.js` *(fails: `deno` command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68540822b684832eb1c8e8ef2c9d2935