### PR TITLE
Add modal zoom animations

### DIFF
--- a/ideas.html
+++ b/ideas.html
@@ -130,6 +130,29 @@
           transform: rotate(360deg);
         }
       }
+
+      #articleModal > div,
+      #settingsPanel > div {
+        transform: scale(0.9);
+        opacity: 0;
+        transition: transform 0.2s, opacity 0.2s;
+      }
+
+      #articleModal.show > div,
+      #settingsPanel.show > div {
+        animation: modalZoom 0.2s forwards;
+      }
+
+      @keyframes modalZoom {
+        from {
+          transform: scale(0.9);
+          opacity: 0;
+        }
+        to {
+          transform: scale(1);
+          opacity: 1;
+        }
+      }
       
     </style>
   </head>
@@ -293,14 +316,14 @@
         function showArticle(html) {
           articleContent.innerHTML = html;
           articleModal.classList.remove("hidden");
-          articleModal.classList.add("flex");
+          articleModal.classList.add("flex", "show");
         }
 
         function showLoading() {
           articleContent.innerHTML =
             '<div class="h-40 flex items-center justify-center"><div class="spinner"></div></div>';
           articleModal.classList.remove("hidden");
-          articleModal.classList.add("flex");
+          articleModal.classList.add("flex", "show");
         }
 
         function showMovie(data) {
@@ -310,12 +333,12 @@
             <p>${data.mov_intro}</p>
           `;
           articleModal.classList.remove("hidden");
-          articleModal.classList.add("flex");
+          articleModal.classList.add("flex", "show");
         }
 
         function hideArticle() {
           articleModal.classList.add("hidden");
-          articleModal.classList.remove("flex");
+          articleModal.classList.remove("flex", "show");
           articleContent.innerHTML = "";
         }
 
@@ -597,12 +620,12 @@
         moreBtn.addEventListener("click", (e) => {
           e.preventDefault();
           settingsPanel.classList.remove("hidden");
-          settingsPanel.classList.add("flex");
+          settingsPanel.classList.add("flex", "show");
         });
 
         closeSettings.addEventListener("click", () => {
           settingsPanel.classList.add("hidden");
-          settingsPanel.classList.remove("flex");
+          settingsPanel.classList.remove("flex", "show");
         });
 
         closeArticle.addEventListener("click", hideArticle);
@@ -619,7 +642,7 @@
           currentPage = 0;
           renderPage();
           settingsPanel.classList.add('hidden');
-          settingsPanel.classList.remove('flex');
+          settingsPanel.classList.remove('flex', 'show');
         });
 
         clearCacheBtn.addEventListener('click', async () => {

--- a/main.html
+++ b/main.html
@@ -97,7 +97,34 @@
       #imageModal img {
         max-width: 90vw;
         max-height: 90vh;
-        transition: transform 0.2s;
+        transform: scale(0.9);
+        opacity: 0;
+        transition: transform 0.2s, opacity 0.2s;
+      }
+
+      #imageModal.show img {
+        animation: modalZoom 0.2s forwards;
+      }
+
+      #settingsPanel > div {
+        transform: scale(0.9);
+        opacity: 0;
+        transition: transform 0.2s, opacity 0.2s;
+      }
+
+      #settingsPanel.show > div {
+        animation: modalZoom 0.2s forwards;
+      }
+
+      @keyframes modalZoom {
+        from {
+          transform: scale(0.9);
+          opacity: 0;
+        }
+        to {
+          transform: scale(1);
+          opacity: 1;
+        }
       }
 
     </style>
@@ -228,14 +255,13 @@
       function openImage(src) {
         imgScale = 1;
         modalImg.src = src;
-        modalImg.style.transform = 'scale(1)';
         imageModal.classList.remove('hidden');
-        imageModal.classList.add('flex');
+        imageModal.classList.add('flex', 'show');
       }
 
       function closeImage() {
         imageModal.classList.add('hidden');
-        imageModal.classList.remove('flex');
+        imageModal.classList.remove('flex', 'show');
         modalImg.src = '';
       }
 
@@ -378,12 +404,12 @@
       moreBtn.addEventListener('click', (e) => {
         e.preventDefault();
         settingsPanel.classList.remove('hidden');
-        settingsPanel.classList.add('flex');
+        settingsPanel.classList.add('flex', 'show');
       });
 
       closeSettings.addEventListener('click', () => {
         settingsPanel.classList.add('hidden');
-        settingsPanel.classList.remove('flex');
+        settingsPanel.classList.remove('flex', 'show');
       });
 
       applySettings.addEventListener('click', () => {
@@ -395,7 +421,7 @@
         currentPage = 0;
         renderPage();
         settingsPanel.classList.add('hidden');
-        settingsPanel.classList.remove('flex');
+        settingsPanel.classList.remove('flex', 'show');
       });
 
       clearCacheBtn.addEventListener('click', async () => {


### PR DESCRIPTION
## Summary
- add zoom-in effect for image, article and settings modals
- adjust JS to toggle new animation state

## Testing
- `deno --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685508ebf298832e816f1af732398493