### PR TITLE
Add admin page to configure API domain

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Admin</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+  </head>
+  <body class="p-4">
+    <h1 class="text-xl font-bold mb-4">设置 API 域名</h1>
+    <div class="mb-4">
+      <input id="domainInput" type="text" placeholder="https://example.com" class="border p-2 w-full" />
+    </div>
+    <button id="saveBtn" class="bg-blue-500 text-white px-4 py-2 rounded">保存</button>
+    <script>
+      const input = document.getElementById('domainInput');
+      input.value = localStorage.getItem('apiDomain') || '';
+      document.getElementById('saveBtn').addEventListener('click', () => {
+        localStorage.setItem('apiDomain', input.value.trim());
+        alert('已保存');
+      });
+    </script>
+  </body>
+</html>

--- a/ideas.html
+++ b/ideas.html
@@ -294,6 +294,11 @@
         const clearCacheBtn = document.getElementById('clearCache');
         let dailyData = null;
 
+        const apiDomain = localStorage.getItem('apiDomain') || '';
+        function withDomain(path) {
+          return apiDomain ? apiDomain.replace(/\/$/, '') + path : path;
+        }
+
         const homeLink = document.querySelector('a[aria-label="\u4e3b\u9875"]');
         let notifyDot = null;
 
@@ -394,7 +399,7 @@
           const img = document.createElement("img");
           img.className =
             "w-full rounded-t-2xl object-cover hover:opacity-90 transition-opacity aspect-video";
-          img.dataset.src = `/img?url=${src}`;
+          img.dataset.src = withDomain(`/img?url=${src}`);
           img.alt = alt;
           img.loading = "lazy";
           const randomHeight = 180 + Math.random() * 120; // 180 - 300px
@@ -457,7 +462,7 @@
               showLoading();
               try {
                 const res = await fetch(
-                  `/api/article?url=${encodeURIComponent(url)}`,
+                  withDomain(`/api/article?url=${encodeURIComponent(url)}`),
                 );
                 html = await res.text();
                 if (res.ok) {
@@ -544,7 +549,7 @@
         }
 
         async function fetchLatest() {
-          const res = await fetch("/api/wx", {
+          const res = await fetch(withDomain("/api/wx"), {
             headers: { "x-skip-cache": "1" },
           });
           if (!res.ok) throw new Error("Network response was not ok");
@@ -552,7 +557,7 @@
         }
 
         async function fetchDaily() {
-          const res = await fetch("/api/daily", {
+          const res = await fetch(withDomain("/api/daily"), {
             headers: { "x-skip-cache": "1" },
           });
           if (!res.ok) throw new Error("Network response was not ok");

--- a/main.html
+++ b/main.html
@@ -233,6 +233,11 @@
       const modalImg = document.getElementById('modalImg');
       let imgScale = 1;
 
+      const apiDomain = localStorage.getItem('apiDomain') || '';
+      function withDomain(path) {
+        return apiDomain ? apiDomain.replace(/\/$/, '') + path : path;
+      }
+
       const homeLink = document.querySelector('a[aria-label="\u4e3b\u9875"]');
       let notifyDot = null;
 
@@ -306,7 +311,7 @@
       function createImage(src, alt) {
         const img = document.createElement('img');
         img.className = 'masonry-item w-full rounded-2xl shadow object-cover hover:opacity-90 transition-opacity';
-        img.dataset.src = `/img?url=${src}`;
+        img.dataset.src = withDomain(`/img?url=${src}`);
         img.alt = alt;
         img.loading = 'lazy';
         // 随机高度以增强瀑布流效果
@@ -366,7 +371,9 @@
       }
 
       async function fetchLatest() {
-        const res = await fetch('/api/wx', { headers: { 'x-skip-cache': '1' } });
+        const res = await fetch(withDomain('/api/wx'), {
+          headers: { 'x-skip-cache': '1' },
+        });
         if (!res.ok) throw new Error('Network response was not ok');
         return await res.json();
       }

--- a/server.ts
+++ b/server.ts
@@ -13,6 +13,7 @@ const __dirname = dirname(fromFileUrl(import.meta.url));
 const indexHtml = await Deno.readTextFile(join(__dirname, "main.html"));
 const ideasHtml = await Deno.readTextFile(join(__dirname, "ideas.html"));
 const swHtml = await Deno.readTextFile(join(__dirname, "sw.js"));
+const adminHtml = await Deno.readTextFile(join(__dirname, "admin.html"));
 const fallbackSentences = [
   "小荷才露尖尖角",
   "早有蜻蜓立上头",
@@ -259,6 +260,13 @@ async function handler(req: Request): Promise<Response> {
     const imgUrl = searchParams.get("url");
     if (!imgUrl) return new Response("missing url", { status: 400 });
     return await proxyImage(imgUrl);
+  }
+
+  // /@admin —— 管理页面
+  if (pathname === "/@admin") {
+    return new Response(adminHtml, {
+      headers: { "Content-Type": "text/html; charset=utf-8" },
+    });
   }
 
   // /ideas —— 灵感瀑布流页面


### PR DESCRIPTION
## Summary
- create **admin.html** for selecting a custom API domain
- serve the admin page at `/@admin`
- update front-end scripts to use the custom domain when fetching images or JSON

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_68550cc6d398832e969f1224c1f00d3e