### PR TITLE
Introduce separate domain settings for APIs and images

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 | 变量 | 默认值 | 说明 |
 | --- | --- | --- |
 | `WX_URL` | `必填` | 获取的微信公众号文章列表，如果不填会从本地 `article.txt` 读取 |
-| `API_DOMAINS` | `(可选)` | 供前端使用的 API 域名，多个域名用逗号或空格分隔 |
+| `API_DOMAINS` | `(可选)` | 提供 `/api/wx`、`/api/article` 和 `/api/daily` 的备用域名，多个域名用逗号或空格分隔 |
+| `IMG_DOMAINS` | `(可选)` | 图片代理 `/img` 的备用域名，多个域名用逗号或空格分隔 |
 
 ## 部署到 Cloudflare Workers
 
@@ -15,4 +16,4 @@
 
 项目中的 HTML 与文本文件会在构建时作为字符串引入，规则已在 `wrangler.toml` 中配置。
 
-Workers 会读取 `WX_URL` 与 `API_DOMAINS` 这两个环境变量。
+Workers 会读取 `WX_URL`、`API_DOMAINS` 和 `IMG_DOMAINS` 这几个环境变量。

--- a/admin.html
+++ b/admin.html
@@ -7,16 +7,24 @@
     <script src="https://cdn.tailwindcss.com"></script>
   </head>
   <body class="p-4">
-    <h1 class="text-xl font-bold mb-4">设置 API 域名（一行一个）</h1>
+    <h1 class="text-xl font-bold mb-2">设置域名（一行一个）</h1>
     <div class="mb-4">
-      <textarea id="domainInput" placeholder="https://a.com" class="border p-2 w-full h-32"></textarea>
+      <label class="block mb-1 font-semibold" for="apiInput">API 域名</label>
+      <textarea id="apiInput" placeholder="https://a.com" class="border p-2 w-full h-24"></textarea>
+    </div>
+    <div class="mb-4">
+      <label class="block mb-1 font-semibold" for="imgInput">图片域名</label>
+      <textarea id="imgInput" placeholder="https://img.com" class="border p-2 w-full h-24"></textarea>
     </div>
     <button id="saveBtn" class="bg-blue-500 text-white px-4 py-2 rounded">保存</button>
     <script>
-      const input = document.getElementById('domainInput');
-      input.value = localStorage.getItem('apiDomains') || localStorage.getItem('apiDomain') || '';
+      const apiInput = document.getElementById('apiInput');
+      const imgInput = document.getElementById('imgInput');
+      apiInput.value = localStorage.getItem('apiDomains') || localStorage.getItem('apiDomain') || '';
+      imgInput.value = localStorage.getItem('imgDomains') || '';
       document.getElementById('saveBtn').addEventListener('click', () => {
-        localStorage.setItem('apiDomains', input.value.trim());
+        localStorage.setItem('apiDomains', apiInput.value.trim());
+        localStorage.setItem('imgDomains', imgInput.value.trim());
         localStorage.removeItem('apiDomain');
         alert('已保存');
       });

--- a/ideas.html
+++ b/ideas.html
@@ -294,37 +294,43 @@
         const clearCacheBtn = document.getElementById('clearCache');
         let dailyData = null;
 
-        const stored = localStorage.getItem('apiDomains') || localStorage.getItem('apiDomain') || '';
-        let apiDomains = stored
-          ? stored.split(/\r?\n|,/).map((s) => s.trim()).filter(Boolean)
+        const apiStored = localStorage.getItem('apiDomains') || localStorage.getItem('apiDomain') || '';
+        const imgStored = localStorage.getItem('imgDomains') || '';
+        let apiDomains = apiStored
+          ? apiStored.split(/\r?\n|,/).map((s) => s.trim()).filter(Boolean)
+          : [];
+        let imgDomains = imgStored
+          ? imgStored.split(/\r?\n|,/).map((s) => s.trim()).filter(Boolean)
           : [];
         if (apiDomains.length === 0 && Array.isArray(window.API_DOMAINS)) {
           apiDomains = window.API_DOMAINS;
+        }
+        if (imgDomains.length === 0 && Array.isArray(window.IMG_DOMAINS)) {
+          imgDomains = window.IMG_DOMAINS;
         }
        function buildUrl(path, domain) {
          return domain ? domain.replace(/\/$/, '') + path : path;
        }
        function withDomain(path) {
-         return buildUrl(path, apiDomains[0]);
+         return buildUrl(path, imgDomains[0]);
        }
         function loadImgWithFallback(img) {
           const path = img.dataset.path;
           if (!path) return;
           let index = 0;
           function attempt() {
-            img.src = buildUrl(path, apiDomains[index] || '');
+            img.src = buildUrl(path, imgDomains[index] || '');
           }
           img.onerror = () => {
             index++;
-            if (index < apiDomains.length) attempt();
+            if (index < imgDomains.length) attempt();
           };
           attempt();
         }
         async function fetchWithFallback(path, options = {}) {
-        if (path.startsWith('/api/wx') || path.startsWith('/api/article') || path.startsWith('/api/daily')) {
-          return fetch(path, options);
-        }
-          for (const d of apiDomains) {
+          const isApi = path.startsWith('/api/wx') || path.startsWith('/api/article') || path.startsWith('/api/daily');
+          const domains = isApi ? apiDomains : imgDomains;
+          for (const d of domains) {
             try {
               const res = await fetch(buildUrl(path, d), options);
               if (res.ok) return res;

--- a/main.html
+++ b/main.html
@@ -233,37 +233,43 @@
       const modalImg = document.getElementById('modalImg');
       let imgScale = 1;
 
-      const stored = localStorage.getItem('apiDomains') || localStorage.getItem('apiDomain') || '';
-      let apiDomains = stored
-        ? stored.split(/\r?\n|,/).map((s) => s.trim()).filter(Boolean)
+      const apiStored = localStorage.getItem('apiDomains') || localStorage.getItem('apiDomain') || '';
+      const imgStored = localStorage.getItem('imgDomains') || '';
+      let apiDomains = apiStored
+        ? apiStored.split(/\r?\n|,/).map((s) => s.trim()).filter(Boolean)
+        : [];
+      let imgDomains = imgStored
+        ? imgStored.split(/\r?\n|,/).map((s) => s.trim()).filter(Boolean)
         : [];
       if (apiDomains.length === 0 && Array.isArray(window.API_DOMAINS)) {
         apiDomains = window.API_DOMAINS;
+      }
+      if (imgDomains.length === 0 && Array.isArray(window.IMG_DOMAINS)) {
+        imgDomains = window.IMG_DOMAINS;
       }
       function buildUrl(path, domain) {
         return domain ? domain.replace(/\/$/, '') + path : path;
       }
       function withDomain(path) {
-        return buildUrl(path, apiDomains[0]);
+        return buildUrl(path, imgDomains[0]);
       }
       function loadImgWithFallback(img) {
         const path = img.dataset.path;
         if (!path) return;
         let index = 0;
         function attempt() {
-          img.src = buildUrl(path, apiDomains[index] || '');
+          img.src = buildUrl(path, imgDomains[index] || '');
         }
         img.onerror = () => {
           index++;
-          if (index < apiDomains.length) attempt();
+          if (index < imgDomains.length) attempt();
         };
         attempt();
       }
       async function fetchWithFallback(path, options = {}) {
-        if (path.startsWith('/api/wx') || path.startsWith('/api/article') || path.startsWith('/api/daily')) {
-          return fetch(path, options);
-        }
-        for (const d of apiDomains) {
+        const isApi = path.startsWith('/api/wx') || path.startsWith('/api/article') || path.startsWith('/api/daily');
+        const domains = isApi ? apiDomains : imgDomains;
+        for (const d of domains) {
           try {
             const res = await fetch(buildUrl(path, d), options);
             if (res.ok) return res;
@@ -361,7 +367,7 @@
           img.style.minHeight = '';
         });
         observer.observe(img);
-        img.addEventListener('click', () => openImage(img.src || buildUrl(img.dataset.path, apiDomains[0])));
+        img.addEventListener('click', () => openImage(img.src || buildUrl(img.dataset.path, imgDomains[0])));
         return img;
       }
 

--- a/server.ts
+++ b/server.ts
@@ -15,10 +15,15 @@ const apiDomains = apiDomainsEnv
   .split(/[,\s]+/)
   .map((d) => d.trim())
   .filter(Boolean);
+const imgDomainsEnv = Deno.env.get("IMG_DOMAINS") || "";
+const imgDomains = imgDomainsEnv
+  .split(/[,\s]+/)
+  .map((d) => d.trim())
+  .filter(Boolean);
 
 function injectConfig(html: string): string {
-  if (apiDomains.length === 0) return html;
-  const script = `<script>window.API_DOMAINS=${JSON.stringify(apiDomains)};</script>`;
+  if (apiDomains.length === 0 && imgDomains.length === 0) return html;
+  const script = `<script>window.API_DOMAINS=${JSON.stringify(apiDomains)};window.IMG_DOMAINS=${JSON.stringify(imgDomains)};</script>`;
   return html.replace("</head>", `${script}</head>`);
 }
 
@@ -244,7 +249,7 @@ async function handler(req: Request): Promise<Response> {
         const src = $(el).attr("data-src") || $(el).attr("src");
         if (src) {
           const imgPath = `/img?url=${encodeURIComponent(src)}`;
-          const domain = apiDomains[0];
+          const domain = imgDomains[0];
           const full = domain ? domain.replace(/\/$/, "") + imgPath : imgPath;
           $(el).attr("src", full);
           $(el).removeAttr("data-src");

--- a/worker.js
+++ b/worker.js
@@ -56,9 +56,11 @@ async function getUrls(env) {
   return urls;
 }
 
-function injectConfig(html, apiDomains) {
-  if (!apiDomains.length) return html;
-  const script = `<script>window.API_DOMAINS=${JSON.stringify(apiDomains)};</script>`;
+function injectConfig(html, apiDomains, imgDomains) {
+  if (!apiDomains.length && !imgDomains.length) return html;
+  const script = `<script>window.API_DOMAINS=${JSON.stringify(
+    apiDomains,
+  )};window.IMG_DOMAINS=${JSON.stringify(imgDomains)};</script>`;
   return html.replace("</head>", `${script}</head>`);
 }
 
@@ -152,10 +154,14 @@ export default {
       .split(/[,\s]+/)
       .map((d) => d.trim())
       .filter(Boolean);
+    const imgDomains = (env.IMG_DOMAINS || "")
+      .split(/[,\s]+/)
+      .map((d) => d.trim())
+      .filter(Boolean);
 
-    const indexHtml = injectConfig(mainHtml, apiDomains);
-    const ideasPage = injectConfig(ideasHtml, apiDomains);
-    const adminPage = injectConfig(adminHtml, apiDomains);
+    const indexHtml = injectConfig(mainHtml, apiDomains, imgDomains);
+    const ideasPage = injectConfig(ideasHtml, apiDomains, imgDomains);
+    const adminPage = injectConfig(adminHtml, apiDomains, imgDomains);
 
     const urls = await getUrls(env);
 


### PR DESCRIPTION
## Summary
- inject `API_DOMAINS` and new `IMG_DOMAINS` into pages
- allow configuring both domains from **@admin** page
- update frontend logic to use `IMG_DOMAINS` for images and `API_DOMAINS` for API calls
- document the new `IMG_DOMAINS` variable

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68556f1db478832e8405843fb607cb09