### PR TITLE
Support CACHE_IMG_DOMAIN in service worker

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -30,6 +30,7 @@ const imgDomains = imgDomainsEnv
   .split(/[,\s]+/)
   .map((d) => d.trim())
   .filter(Boolean);
+const cacheImgDomain = Deno.env.get("CACHE_IMG_DOMAIN") || "";
 
 function injectConfig(html: string): string {
   if (apiDomains.length === 0 && imgDomains.length === 0) return html;
@@ -43,7 +44,8 @@ const indexHtml = injectConfig(
 const ideasHtml = injectConfig(
   await Deno.readTextFile(join(__dirname, "ideas.html")),
 );
-const swHtml = await Deno.readTextFile(join(__dirname, "sw.js"));
+const swRaw = await Deno.readTextFile(join(__dirname, "sw.js"));
+const swHtml = `const CACHE_IMG_DOMAIN = ${JSON.stringify(cacheImgDomain)};\n${swRaw}`;
 const adminHtml = injectConfig(
   await Deno.readTextFile(join(__dirname, "admin.html")),
 );

--- a/server.ts
+++ b/server.ts
@@ -30,7 +30,7 @@ const imgDomains = imgDomainsEnv
   .split(/[,\s]+/)
   .map((d) => d.trim())
   .filter(Boolean);
-const cacheImgDomain = Deno.env.get("CACHE_IMG_DOMAIN") || "";
+const cacheImgDomain = Deno.env.get("IMG_CACHE") || "";
 
 function injectConfig(html: string): string {
   if (apiDomains.length === 0 && imgDomains.length === 0) return html;
@@ -45,7 +45,7 @@ const ideasHtml = injectConfig(
   await Deno.readTextFile(join(__dirname, "ideas.html")),
 );
 const swRaw = await Deno.readTextFile(join(__dirname, "sw.js"));
-const swHtml = `const CACHE_IMG_DOMAIN = ${JSON.stringify(cacheImgDomain)};\n${swRaw}`;
+const swHtml = `const IMG_CACHE = ${JSON.stringify(cacheImgDomain)};\n${swRaw}`;
 const adminHtml = injectConfig(
   await Deno.readTextFile(join(__dirname, "admin.html")),
 );

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
 const CACHE_NAME = "wx-cache-v2";
-const CACHE_IMG_DOMAIN = "";
+const IMG_CACHE = "";
 
 self.addEventListener("install", (event) => {
   self.skipWaiting();
@@ -27,7 +27,7 @@ self.addEventListener("fetch", (event) => {
     } else {
       event.respondWith(cacheThenNetwork(event.request));
     }
-  } else if (url.pathname.startsWith("/img") && url.hostname === CACHE_IMG_DOMAIN) {
+  } else if (url.pathname.startsWith("/img") && url.hostname === IMG_CACHE) {
     event.respondWith(cacheThenNetwork(event.request));
   } else if (url.pathname === "/api/article") {
     event.respondWith(cacheThenNetwork(event.request));

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,5 @@
 const CACHE_NAME = "wx-cache-v2";
+const CACHE_IMG_DOMAIN = "";
 
 self.addEventListener("install", (event) => {
   self.skipWaiting();
@@ -26,7 +27,7 @@ self.addEventListener("fetch", (event) => {
     } else {
       event.respondWith(cacheThenNetwork(event.request));
     }
-  } else if (url.pathname.startsWith("/img")) {
+  } else if (url.pathname.startsWith("/img") && url.hostname === CACHE_IMG_DOMAIN) {
     event.respondWith(cacheThenNetwork(event.request));
   } else if (url.pathname === "/api/article") {
     event.respondWith(cacheThenNetwork(event.request));

--- a/worker.js
+++ b/worker.js
@@ -175,7 +175,7 @@ export default {
       .split(/[,\s]+/)
       .map((d) => d.trim())
       .filter(Boolean);
-    const cacheImgDomain = env.CACHE_IMG_DOMAIN || "";
+    const cacheImgDomain = env.IMG_CACHE || "";
 
     const indexHtml = injectConfig(mainHtml, apiDomains, imgDomains);
     const ideasPage = injectConfig(ideasHtml, apiDomains, imgDomains);
@@ -254,7 +254,7 @@ export default {
 
     if (pathname === "/sw.js") {
         const swHtml = `
-const CACHE_IMG_DOMAIN = ${JSON.stringify(cacheImgDomain)};
+const IMG_CACHE = ${JSON.stringify(cacheImgDomain)};
 const CACHE_NAME = "wx-cache-v2";
 
 self.addEventListener("install", (event) => {
@@ -283,7 +283,7 @@ self.addEventListener("fetch", (event) => {
     } else {
       event.respondWith(cacheThenNetwork(event.request));
     }
-  } else if (url.pathname.startsWith("/img") && url.hostname === CACHE_IMG_DOMAIN) {
+  } else if (url.pathname.startsWith("/img") && url.hostname === IMG_CACHE) {
     event.respondWith(cacheThenNetwork(event.request));
   } else if (url.pathname === "/api/article") {
     event.respondWith(cacheThenNetwork(event.request));

--- a/worker.js
+++ b/worker.js
@@ -175,6 +175,7 @@ export default {
       .split(/[,\s]+/)
       .map((d) => d.trim())
       .filter(Boolean);
+    const cacheImgDomain = env.CACHE_IMG_DOMAIN || "";
 
     const indexHtml = injectConfig(mainHtml, apiDomains, imgDomains);
     const ideasPage = injectConfig(ideasHtml, apiDomains, imgDomains);
@@ -253,6 +254,7 @@ export default {
 
     if (pathname === "/sw.js") {
         const swHtml = `
+const CACHE_IMG_DOMAIN = ${JSON.stringify(cacheImgDomain)};
 const CACHE_NAME = "wx-cache-v2";
 
 self.addEventListener("install", (event) => {
@@ -281,7 +283,7 @@ self.addEventListener("fetch", (event) => {
     } else {
       event.respondWith(cacheThenNetwork(event.request));
     }
-  } else if (url.pathname.startsWith("/img")) {
+  } else if (url.pathname.startsWith("/img") && url.hostname === CACHE_IMG_DOMAIN) {
     event.respondWith(cacheThenNetwork(event.request));
   } else if (url.pathname === "/api/article") {
     event.respondWith(cacheThenNetwork(event.request));


### PR DESCRIPTION
## Summary
- add `CACHE_IMG_DOMAIN` to `server.ts` and `worker.js`
- inject `CACHE_IMG_DOMAIN` constant when serving `/sw.js`
- only cache images from the allowed host

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68560246f914832e916a65bb3d0a816d