### PR TITLE
Fix caching for cross-origin images

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -56,7 +56,7 @@ function matchImgCache(url) {
 async function fetchAndCache(request) {
   const cache = await caches.open(CACHE_NAME);
   const res = await fetch(request);
-  if (res.ok) await cache.put(request, res.clone());
+  if (res.ok || res.type === "opaque") await cache.put(request, res.clone());
   return res;
 }
 
@@ -66,14 +66,14 @@ async function cacheThenNetwork(request) {
   if (cached) {
     fetch(request)
       .then((res) => {
-        if (res.ok) cache.put(request, res.clone());
+        if (res.ok || res.type === "opaque") cache.put(request, res.clone());
       })
       .catch(() => {});
     return cached;
   }
   try {
     const res = await fetch(request);
-    if (res.ok) await cache.put(request, res.clone());
+    if (res.ok || res.type === "opaque") await cache.put(request, res.clone());
     return res;
   } catch (err) {
     if (cached) return cached;

--- a/worker.js
+++ b/worker.js
@@ -313,7 +313,7 @@ function matchImgCache(url) {
 async function fetchAndCache(request) {
   const cache = await caches.open(CACHE_NAME);
   const res = await fetch(request);
-  if (res.ok) await cache.put(request, res.clone());
+  if (res.ok || res.type === "opaque") await cache.put(request, res.clone());
   return res;
 }
 
@@ -323,14 +323,14 @@ async function cacheThenNetwork(request) {
   if (cached) {
     fetch(request)
       .then((res) => {
-        if (res.ok) cache.put(request, res.clone());
+        if (res.ok || res.type === "opaque") cache.put(request, res.clone());
       })
       .catch(() => {});
     return cached;
   }
   try {
     const res = await fetch(request);
-    if (res.ok) await cache.put(request, res.clone());
+    if (res.ok || res.type === "opaque") await cache.put(request, res.clone());
     return res;
   } catch (err) {
     if (cached) return cached;


### PR DESCRIPTION
## Summary
- allow service worker to cache opaque (no-cors) image responses

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68561b0e2e4c832e8d7340cf5f1f61e3