### PR TITLE
Fix repeated cache refresh

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -70,20 +70,11 @@ async function cacheThenNetwork(request) {
   const cache = await caches.open(CACHE_NAME);
   const meta = await caches.open(META_CACHE);
   const cached = await cache.match(request);
-  const isImg = request.destination === "image";
   if (cached) {
     const metaRes = await meta.match(request.url);
-    if (isImg && metaRes) {
+    if (metaRes) {
       const ts = parseInt(await metaRes.text());
       if (!Number.isNaN(ts) && Date.now() - ts < CACHE_AGE) {
-        fetch(request)
-          .then(async (res) => {
-            if (res.ok || res.type === "opaque") {
-              await cache.put(request, res.clone());
-              await meta.put(request.url, new Response(Date.now().toString()));
-            }
-          })
-          .catch(() => {});
         return cached;
       }
     }

--- a/worker.js
+++ b/worker.js
@@ -327,20 +327,11 @@ async function cacheThenNetwork(request) {
   const cache = await caches.open(CACHE_NAME);
   const meta = await caches.open(META_CACHE);
   const cached = await cache.match(request);
-  const isImg = request.destination === "image";
   if (cached) {
     const metaRes = await meta.match(request.url);
-    if (isImg && metaRes) {
+    if (metaRes) {
       const ts = parseInt(await metaRes.text());
       if (!Number.isNaN(ts) && Date.now() - ts < CACHE_AGE) {
-        fetch(request)
-          .then(async (res) => {
-            if (res.ok || res.type === "opaque") {
-              await cache.put(request, res.clone());
-              await meta.put(request.url, new Response(Date.now().toString()));
-            }
-          })
-          .catch(() => {});
         return cached;
       }
     }


### PR DESCRIPTION
## Summary
- avoid repeatedly refreshing the cache by respecting cached entry age

## Testing
- `node --check worker.js`
- `node --check sw.js`


------
https://chatgpt.com/codex/tasks/task_b_68563a5b5314832e80830664ee9b3481