### PR TITLE
Store cache timestamp in response header

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -34,8 +34,8 @@
       });
 
       const CACHE_NAME = 'wx-cache-v2';
-      const META_CACHE = 'wx-cache-meta-v1';
       const CACHE_AGE = 6 * 24 * 60 * 60 * 1000;
+      const TS_HEADER = 'X-Cache-Timestamp';
 
       async function loadCache() {
         const box = document.getElementById('cacheInfo');
@@ -45,7 +45,6 @@
         }
         try {
           const cache = await caches.open(CACHE_NAME);
-          const meta = await caches.open(META_CACHE);
           const keys = await cache.keys();
           if (keys.length === 0) {
             box.textContent = '无缓存数据';
@@ -53,11 +52,11 @@
           }
           const items = [];
           for (const req of keys) {
-            const metaRes = await meta.match(req.url);
+            const cachedRes = await cache.match(req.url);
             let cachedTime = '未知';
             let expireTime = '未知';
-            if (metaRes) {
-              const ts = parseInt(await metaRes.text());
+            if (cachedRes) {
+              const ts = parseInt(cachedRes.headers.get(TS_HEADER));
               if (!Number.isNaN(ts)) {
                 cachedTime = new Date(ts).toLocaleString();
                 expireTime = new Date(ts + CACHE_AGE).toLocaleString();

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 const CACHE_NAME = "wx-cache-v2";
-const META_CACHE = "wx-cache-meta-v1";
 const CACHE_AGE = 6 * 24 * 60 * 60 * 1000;
+const TS_HEADER = "X-Cache-Timestamp";
 
 self.addEventListener("install", (event) => {
   self.skipWaiting();
@@ -12,7 +12,7 @@ self.addEventListener("activate", (event) => {
     caches.keys().then((names) =>
       Promise.all(
         names
-          .filter((n) => n !== CACHE_NAME && n !== META_CACHE)
+          .filter((n) => n !== CACHE_NAME)
           .map((n) => caches.delete(n)),
       ),
     ),
@@ -59,30 +59,39 @@ async function fetchAndCache(request) {
   const cache = await caches.open(CACHE_NAME);
   const res = await fetch(request);
   if (res.ok || res.type === "opaque") {
-    await cache.put(request, res.clone());
-    const meta = await caches.open(META_CACHE);
-    await meta.put(request.url, new Response(Date.now().toString()));
+    const resForCache = res.clone();
+    const headers = new Headers(resForCache.headers);
+    headers.set(TS_HEADER, Date.now().toString());
+    const cachedRes = new Response(resForCache.body, {
+      status: resForCache.status,
+      statusText: resForCache.statusText,
+      headers,
+    });
+    await cache.put(request, cachedRes);
   }
   return res;
 }
 
 async function cacheThenNetwork(request) {
   const cache = await caches.open(CACHE_NAME);
-  const meta = await caches.open(META_CACHE);
   const cached = await cache.match(request);
   if (cached) {
-    const metaRes = await meta.match(request.url);
-    if (metaRes) {
-      const ts = parseInt(await metaRes.text());
-      if (!Number.isNaN(ts) && Date.now() - ts < CACHE_AGE) {
-        return cached;
-      }
+    const ts = parseInt(cached.headers.get(TS_HEADER) || "0");
+    if (!Number.isNaN(ts) && Date.now() - ts < CACHE_AGE) {
+      return cached;
     }
     fetch(request)
       .then(async (res) => {
         if (res.ok || res.type === "opaque") {
-          await cache.put(request, res.clone());
-          await meta.put(request.url, new Response(Date.now().toString()));
+          const resForCache = res.clone();
+          const headers = new Headers(resForCache.headers);
+          headers.set(TS_HEADER, Date.now().toString());
+          const cachedRes = new Response(resForCache.body, {
+            status: resForCache.status,
+            statusText: resForCache.statusText,
+            headers,
+          });
+          await cache.put(request, cachedRes);
         }
       })
       .catch(() => {});
@@ -91,8 +100,15 @@ async function cacheThenNetwork(request) {
   try {
     const res = await fetch(request);
     if (res.ok || res.type === "opaque") {
-      await cache.put(request, res.clone());
-      await meta.put(request.url, new Response(Date.now().toString()));
+      const resForCache = res.clone();
+      const headers = new Headers(resForCache.headers);
+      headers.set(TS_HEADER, Date.now().toString());
+      const cachedRes = new Response(resForCache.body, {
+        status: resForCache.status,
+        statusText: resForCache.statusText,
+        headers,
+      });
+      await cache.put(request, cachedRes);
     }
     return res;
   } catch (err) {

--- a/worker.js
+++ b/worker.js
@@ -256,8 +256,8 @@ export default {
         const swHtml = `
 const IMG_CACHE = ${JSON.stringify(cacheImgDomain)};
 const CACHE_NAME = "wx-cache-v2";
-const META_CACHE = "wx-cache-meta-v1";
 const CACHE_AGE = 6 * 24 * 60 * 60 * 1000;
+const TS_HEADER = "X-Cache-Timestamp";
 
 self.addEventListener("install", (event) => {
   self.skipWaiting();
@@ -269,7 +269,7 @@ self.addEventListener("activate", (event) => {
     caches.keys().then((names) =>
       Promise.all(
         names
-          .filter((n) => n !== CACHE_NAME && n !== META_CACHE)
+          .filter((n) => n !== CACHE_NAME)
           .map((n) => caches.delete(n)),
       ),
     ),
@@ -316,30 +316,39 @@ async function fetchAndCache(request) {
   const cache = await caches.open(CACHE_NAME);
   const res = await fetch(request);
   if (res.ok || res.type === "opaque") {
-    await cache.put(request, res.clone());
-    const meta = await caches.open(META_CACHE);
-    await meta.put(request.url, new Response(Date.now().toString()));
+    const resForCache = res.clone();
+    const headers = new Headers(resForCache.headers);
+    headers.set(TS_HEADER, Date.now().toString());
+    const cachedRes = new Response(resForCache.body, {
+      status: resForCache.status,
+      statusText: resForCache.statusText,
+      headers,
+    });
+    await cache.put(request, cachedRes);
   }
   return res;
 }
 
 async function cacheThenNetwork(request) {
   const cache = await caches.open(CACHE_NAME);
-  const meta = await caches.open(META_CACHE);
   const cached = await cache.match(request);
   if (cached) {
-    const metaRes = await meta.match(request.url);
-    if (metaRes) {
-      const ts = parseInt(await metaRes.text());
-      if (!Number.isNaN(ts) && Date.now() - ts < CACHE_AGE) {
-        return cached;
-      }
+    const ts = parseInt(cached.headers.get(TS_HEADER) || "0");
+    if (!Number.isNaN(ts) && Date.now() - ts < CACHE_AGE) {
+      return cached;
     }
     fetch(request)
       .then(async (res) => {
         if (res.ok || res.type === "opaque") {
-          await cache.put(request, res.clone());
-          await meta.put(request.url, new Response(Date.now().toString()));
+          const resForCache = res.clone();
+          const headers = new Headers(resForCache.headers);
+          headers.set(TS_HEADER, Date.now().toString());
+          const cachedRes = new Response(resForCache.body, {
+            status: resForCache.status,
+            statusText: resForCache.statusText,
+            headers,
+          });
+          await cache.put(request, cachedRes);
         }
       })
       .catch(() => {});
@@ -348,8 +357,15 @@ async function cacheThenNetwork(request) {
   try {
     const res = await fetch(request);
     if (res.ok || res.type === "opaque") {
-      await cache.put(request, res.clone());
-      await meta.put(request.url, new Response(Date.now().toString()));
+      const resForCache = res.clone();
+      const headers = new Headers(resForCache.headers);
+      headers.set(TS_HEADER, Date.now().toString());
+      const cachedRes = new Response(resForCache.body, {
+        status: resForCache.status,
+        statusText: resForCache.statusText,
+        headers,
+      });
+      await cache.put(request, cachedRes);
     }
     return res;
   } catch (err) {


### PR DESCRIPTION
## Summary
- replace META_CACHE with custom `X-Cache-Timestamp` header
- update Service Worker logic to read/write the timestamp header
- adjust admin page to display cache info using the new header

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68563d0657b8832e8b6a721fcb9e589b