### PR TITLE
Fix dark mode toggle to revert to light theme

### DIFF
--- a/ideas.html
+++ b/ideas.html
@@ -5,6 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>文章列表</title>
     <!-- Tailwind CDN -->
+    <script>
+      tailwind.config = { darkMode: 'class' };
+    </script>
     <script src="https://cdn.tailwindcss.com"></script>
     <style>
       /* Masonry 布局 */

--- a/main.html
+++ b/main.html
@@ -5,6 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>我的作品集</title>
     <!-- Tailwind CDN -->
+    <script>
+      tailwind.config = { darkMode: 'class' };
+    </script>
     <script src="https://cdn.tailwindcss.com"></script>
     <style>
       /* Masonry 布局 */


### PR DESCRIPTION
## Summary
- configure Tailwind to use `darkMode: 'class'`
- fixes background and cards not reverting to light theme

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6856905ed7e4832e9f277aee732f2823