### PR TITLE
Add RSS reader page

### DIFF
--- a/add.html
+++ b/add.html
@@ -1,0 +1,172 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>RSS 阅读器</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <style>
+      :root {
+        --primary: 79, 70, 229;
+        --secondary: 139, 92, 246;
+        --accent: 236, 72, 153;
+        --surface: 241, 245, 249;
+        --on-surface: 15, 23, 42;
+        --card: 255, 255, 255;
+        --border: 229, 231, 235;
+      }
+      .dark {
+        --primary: 129, 140, 248;
+        --secondary: 167, 139, 250;
+        --accent: 244, 114, 182;
+        --surface: 15, 23, 42;
+        --on-surface: 241, 245, 249;
+        --card: 30, 41, 59;
+        --border: 55, 65, 81;
+      }
+      .masonry {
+        column-count: 3;
+        column-gap: 1rem;
+      }
+      @media (max-width: 1024px) {
+        .masonry {
+          column-count: 2;
+        }
+      }
+      @media (max-width: 640px) {
+        .masonry {
+          column-count: 1;
+        }
+      }
+      .masonry-item {
+        break-inside: avoid;
+        margin-bottom: 1rem;
+      }
+      .sidebar-link {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 0.5rem;
+        border-radius: 0.375rem;
+        color: #6b7280;
+        transition:
+          background-color 0.2s,
+          color 0.2s;
+      }
+      .sidebar-link:hover {
+        background-color: #f1f5f9;
+        color: #111827;
+      }
+    </style>
+    <script>
+      tailwind.config = {
+        darkMode: "class",
+        theme: {
+          extend: {
+            colors: {
+              primary: "rgb(var(--primary))",
+              secondary: "rgb(var(--secondary))",
+              accent: "rgb(var(--accent))",
+              surface: "rgb(var(--surface))",
+              "on-surface": "rgb(var(--on-surface))",
+              card: "rgb(var(--card))",
+              border: "rgb(var(--border))",
+            },
+          },
+        },
+      };
+    </script>
+  </head>
+  <body class="bg-surface text-on-surface min-h-screen font-sans">
+    <nav
+      class="fixed top-0 left-0 h-screen w-[72px] border-r shadow flex flex-col items-center py-4"
+    >
+      <div
+        class="sidebar-items flex flex-col items-center gap-y-6 h-full w-full"
+      >
+        <a href="/#" aria-label="主页" class="sidebar-link">
+          <svg viewBox="0 0 24 24" fill="currentColor" class="w-6 h-6">
+            <path
+              d="M7.54 23.15q-.2-2.05.26-3.93L9 14.04a7 7 0 0 1-.35-2.07c0-1.68.81-2.88 2.09-2.88.88 0 1.53.62 1.53 1.8q0 .57-.23 1.28l-.52 1.72q-.15.5-.15.92c0 1.2.91 1.87 2.08 1.87 2.09 0 3.57-2.16 3.57-4.96 0-3.12-2.04-5.12-5.05-5.12-3.36 0-5.49 2.19-5.49 5.24 0 1.22.38 2.36 1.11 3.14-.24.41-.5.48-.88.48-1.2 0-2.34-1.69-2.34-4 0-4 3.2-7.17 7.68-7.17 4.7 0 7.66 3.29 7.66 7.33s-2.88 7.15-5.98 7.15a3.8 3.8 0 0 1-3.06-1.48l-.62 2.5a11 11 0 0 1-1.62 3.67A11.98 11.98 0 0 0 24 12a11.99 11.99 0 1 0-24 0 12 12 0 0 0 7.54 11.15"
+            />
+          </svg>
+        </a>
+        <a href="/" aria-label="首页" class="sidebar-link" id="homeBtn">
+          <svg viewBox="0 0 24 24" fill="currentColor" class="w-6 h-6">
+            <path
+              d="M4.6 22.73A107 107 0 0 0 11 23h2.22c2.43-.04 4.6-.16 6.18-.27A3.9 3.9 0 0 0 23 18.8v-8.46a4 4 0 0 0-1.34-3L14.4.93a3.63 3.63 0 0 0-4.82 0L2.34 7.36A4 4 0 0 0 1 10.35v8.46a3.9 3.9 0 0 0 3.6 3.92M13.08 2.4l7.25 6.44a2 2 0 0 1 .67 1.5v8.46a1.9 1.9 0 0 1-1.74 1.92q-1.39.11-3.26.19V16a4 4 0 0 0-8 0v4.92q-1.87-.08-3.26-.19A1.9 1.9 0 0 1 3 18.81v-8.46a2 2 0 0 1 .67-1.5l7.25-6.44a1.63 1.63 0 0 1 2.16 0M13.12 21h-2.24a1 1 0 0 1-.88-1v-4a2 2 0 1 1 4 0v4a1 1 0 0 1-.88 1"
+            />
+          </svg>
+        </a>
+        <a href="/ideas" aria-label="探索" id="idealBtn" class="sidebar-link">
+          <svg viewBox="0 0 24 24" fill="currentColor" class="w-6 h-6">
+            <path
+              d="M12 14a2 2 0 1 0 0-4 2 2 0 0 0 0 4M9.42 7.24a3 3 0 0 0-2.18 2.18L5.7 15.57a2.25 2.25 0 0 0 2.73 2.73l6.15-1.54a3 3 0 0 0 2.18-2.18l1.54-6.15a2.25 2.25 0 0 0-2.73-2.73zm6.94.7-1.54 6.15a1 1 0 0 1-.73.73l-6.15 1.54a.25.25 0 0 1-.3-.3L9.18 9.9a1 1 0 0 1 .73-.73l6.15-1.54a.25.25 0 0 1 .3.3M12 24a12 12 0 1 0 0-24 12 12 0 0 0 0 24M2 12a10 10 0 1 1 20 0 10 10 0 0 1-20 0"
+            />
+          </svg>
+        </a>
+        <a href="/add" aria-label="创建" id="addBtn" class="sidebar-link">
+          <svg viewBox="0 0 24 24" fill="currentColor" class="w-6 h-6">
+            <path
+              d="M11 11H6v2h5v5h2v-5h5v-2h-5V6h-2zM5 1a4 4 0 0 0-4 4v14a4 4 0 0 0 4 4h14a4 4 0 0 0 4-4V5a4 4 0 0 0-4-4zm16 4v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5c0-1.1.9-2 2-2h14a2 2 0 0 1 2 2"
+            />
+          </svg>
+        </a>
+      </div>
+    </nav>
+    <div id="content" class="ml-[72px]">
+      <header class="py-6 text-center">
+        <h1 class="text-3xl font-bold tracking-tight text-on-surface">
+          RSS 阅读器
+        </h1>
+      </header>
+      <main class="px-4 max-w-screen-xl mx-auto">
+        <div class="masonry" id="feedList"></div>
+      </main>
+    </div>
+    <script>
+      document.addEventListener("DOMContentLoaded", async () => {
+        const feedList = document.getElementById("feedList");
+        const defaults = Array.isArray(window.DEFAULT_FEEDS)
+          ? window.DEFAULT_FEEDS
+          : [];
+        const extra = (localStorage.getItem("rssFeeds") || "")
+          .split(/\r?\n|,/)
+          .map((s) => s.trim())
+          .filter(Boolean);
+        const feeds = defaults.concat(extra);
+        async function load(url) {
+          const res = await fetch("/api/rss?url=" + encodeURIComponent(url));
+          if (!res.ok) throw new Error("fail");
+          return (await res.json()).items || [];
+        }
+        for (const url of feeds) {
+          try {
+            const items = await load(url);
+            for (const it of items) {
+              const card = document.createElement("div");
+              card.className = "masonry-item rounded-2xl shadow bg-card p-4";
+              const title = document.createElement("h2");
+              title.className = "text-lg font-semibold mb-2";
+              title.textContent = it.title;
+              const desc = document.createElement("p");
+              desc.className = "text-sm text-gray-600 mb-2";
+              desc.innerHTML = it.description;
+              const link = document.createElement("a");
+              link.href = it.link;
+              link.target = "_blank";
+              link.className = "text-xs text-gray-400 hover:underline self-end";
+              link.textContent = "查看原文";
+              card.appendChild(title);
+              card.appendChild(desc);
+              card.appendChild(link);
+              feedList.appendChild(card);
+            }
+          } catch (e) {
+            console.error(e);
+          }
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/add.html
+++ b/add.html
@@ -130,38 +130,49 @@
         const defaults = Array.isArray(window.DEFAULT_FEEDS)
           ? window.DEFAULT_FEEDS
           : [];
+        const preloaded = Array.isArray(window.PRELOAD_ITEMS)
+          ? window.PRELOAD_ITEMS
+          : [];
         const extra = (localStorage.getItem("rssFeeds") || "")
           .split(/\r?\n|,/)
           .map((s) => s.trim())
-          .filter(Boolean);
-        const feeds = defaults.concat(extra);
+          .filter(Boolean)
+          .filter((u) => !defaults.includes(u));
+
+        function render(items) {
+          for (const it of items) {
+            const card = document.createElement("div");
+            card.className = "masonry-item rounded-2xl shadow bg-card p-4";
+            const title = document.createElement("h2");
+            title.className = "text-lg font-semibold mb-2";
+            title.textContent = it.title;
+            const desc = document.createElement("p");
+            desc.className = "text-sm text-gray-600 mb-2";
+            desc.innerHTML = it.description;
+            const link = document.createElement("a");
+            link.href = it.link;
+            link.target = "_blank";
+            link.className = "text-xs text-gray-400 hover:underline self-end";
+            link.textContent = "查看原文";
+            card.appendChild(title);
+            card.appendChild(desc);
+            card.appendChild(link);
+            feedList.appendChild(card);
+          }
+        }
+
+        render(preloaded);
+
         async function load(url) {
           const res = await fetch("/api/rss?url=" + encodeURIComponent(url));
           if (!res.ok) throw new Error("fail");
           return (await res.json()).items || [];
         }
-        for (const url of feeds) {
+
+        for (const url of extra) {
           try {
             const items = await load(url);
-            for (const it of items) {
-              const card = document.createElement("div");
-              card.className = "masonry-item rounded-2xl shadow bg-card p-4";
-              const title = document.createElement("h2");
-              title.className = "text-lg font-semibold mb-2";
-              title.textContent = it.title;
-              const desc = document.createElement("p");
-              desc.className = "text-sm text-gray-600 mb-2";
-              desc.innerHTML = it.description;
-              const link = document.createElement("a");
-              link.href = it.link;
-              link.target = "_blank";
-              link.className = "text-xs text-gray-400 hover:underline self-end";
-              link.textContent = "查看原文";
-              card.appendChild(title);
-              card.appendChild(desc);
-              card.appendChild(link);
-              feedList.appendChild(card);
-            }
+            render(items);
           } catch (e) {
             console.error(e);
           }

--- a/add.html
+++ b/add.html
@@ -393,7 +393,7 @@
   <div id="content" class="ml-[72px]">
     <header class="py-6 px-4 max-w-screen-xl mx-auto">
       <div class="rss-header">
-        <div class="rss-avatar">金</div>
+        <div class="rss-avatar"></div>
         <div class="rss-info">
           <h1 class="text-3xl font-bold tracking-tight text-on-surface">
             金桔猪的收藏
@@ -516,106 +516,45 @@
         const articleContent = document.getElementById("articleContent");
         const clearCacheBtn = document.getElementById('clearCache');
         
-        // RSS源数据（模拟豆瓣收藏）
-        const rssData = [
-          {
-            title: "看过阿诺拉",
-            link: "https://movie.douban.com/subject/36195543/",
-            imgSrc: "https://img1.doubanio.com/view/photo/s_ratio_poster/public/p2912764859.webp",
-            creator: "金桔猪",
-            pubDate: "2025-02-21",
-            type: "movie"
-          },
-          {
-            title: "看过新宿野战医院",
-            link: "https://movie.douban.com/subject/36902609/",
-            imgSrc: "https://img1.doubanio.com/view/photo/s_ratio_poster/public/p2909993898.webp",
-            creator: "金桔猪",
-            pubDate: "2024-12-07",
-            type: "movie"
-          },
-          {
-            title: "想看荒野机器人",
-            link: "https://movie.douban.com/subject/36689857/",
-            imgSrc: "https://img2.doubanio.com/view/photo/s_ratio_poster/public/p2913022141.webp",
-            creator: "金桔猪",
-            pubDate: "2024-11-17",
-            type: "movie"
-          },
-          {
-            title: "看过某种物质",
-            link: "https://movie.douban.com/subject/35882838/",
-            imgSrc: "https://img1.doubanio.com/view/photo/s_ratio_poster/public/p2912441039.webp",
-            creator: "金桔猪",
-            pubDate: "2024-11-17",
-            type: "movie"
-          },
-          {
-            title: "看过小妇人",
-            link: "https://movie.douban.com/subject/26348103/",
-            imgSrc: "https://img9.doubanio.com/view/photo/s_ratio_poster/public/p2572928166.webp",
-            creator: "金桔猪",
-            pubDate: "2024-11-12",
-            type: "movie"
-          },
-          {
-            title: "看过他是龙",
-            link: "https://movie.douban.com/subject/26726098/",
-            imgSrc: "https://img2.doubanio.com/view/photo/s_ratio_poster/public/p2374045871.webp",
-            creator: "金桔猪",
-            pubDate: "2024-09-17",
-            type: "movie"
-          },
-          {
-            title: "看过死侍与金刚狼",
-            link: "https://movie.douban.com/subject/26957900/",
-            imgSrc: "https://img9.doubanio.com/view/photo/s_ratio_poster/public/p2908440764.webp",
-            creator: "金桔猪",
-            pubDate: "2024-08-11",
-            type: "movie"
-          },
-          {
-            title: "看过塔罗牌",
-            link: "https://movie.douban.com/subject/36733268/",
-            imgSrc: "https://img3.doubanio.com/view/photo/s_ratio_poster/public/p2911767273.webp",
-            creator: "金桔猪",
-            pubDate: "2024-08-11",
-            type: "movie"
-          },
-          {
-            title: "想读“没话找话”指南",
-            link: "https://book.douban.com/subject/36124823/",
-            imgSrc: "https://img9.doubanio.com/view/subject/s/public/s34330754.jpg",
-            creator: "金桔猪",
-            pubDate: "2024-06-24",
-            type: "book"
-          },
-          {
-            title: "想读日常生活中的非暴力沟通",
-            link: "https://book.douban.com/subject/36506276/",
-            imgSrc: "https://img3.doubanio.com/view/subject/s/public/s34619022.jpg",
-            creator: "金桔猪",
-            pubDate: "2024-06-24",
-            type: "book"
-          },
-          {
-            title: "听过Midnights",
-            link: "https://music.douban.com/subject/36130489/",
-            imgSrc: "https://img9.doubanio.com/view/subject/s/public/s34359738.jpg",
-            creator: "金桔猪",
-            pubDate: "2024-05-15",
-            type: "music"
-          },
-          {
-            title: "听过30",
-            link: "https://music.douban.com/subject/35669718/",
-            imgSrc: "https://img1.doubanio.com/view/subject/s/public/s34036615.jpg",
-            creator: "金桔猪",
-            pubDate: "2024-04-10",
-            type: "music"
-          }
-        ];
+async function fetchRSS() {
 
+const url = 'https://www.douban.com/feed/people/pigpigeon/interests';
+
+try {
+
+// 使用代理，假设我们的代理接口在同源下
+
+const res = await fetch(`${encodeURIComponent(url)}`);
+
+if (res.ok) {
+
+const text = await res.text();
+
+return parseRSS(text);
+
+} else {
+
+throw new Error('Network error');
+
+}
+
+} catch (err) {
+
+console.error('使用代理获取RSS失败，使用模拟数据', err);
+
+// 使用模拟数据
+return parseRSS(text);
+
+}
+
+}
+
+function parseRSS(text) {
+
+const parser = new DOMParser();
+
+const xmlDoc = parser.parseFromString(text, "text/xml");
+  
         const navEl = document.querySelector("nav");
         const contentEl = document.getElementById("content");
         const isMobile = /Mobi|Android|iPhone|Windows Phone/i.test(

--- a/add.html
+++ b/add.html
@@ -1,183 +1,864 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="zh-CN">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>RSS 阅读器</title>
-    <script src="https://cdn.tailwindcss.com"></script>
-    <style>
-      :root {
-        --primary: 79, 70, 229;
-        --secondary: 139, 92, 246;
-        --accent: 236, 72, 153;
-        --surface: 241, 245, 249;
-        --on-surface: 15, 23, 42;
-        --card: 255, 255, 255;
-        --border: 229, 231, 235;
-      }
-      .dark {
-        --primary: 129, 140, 248;
-        --secondary: 167, 139, 250;
-        --accent: 244, 114, 182;
-        --surface: 15, 23, 42;
-        --on-surface: 241, 245, 249;
-        --card: 30, 41, 59;
-        --border: 55, 65, 81;
-      }
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>RSS阅读器</title>
+  <!-- Tailwind CDN -->
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>
+    /* 自定义主题色卡 */
+    :root {
+      --primary: 79, 70, 229;
+      --secondary: 139, 92, 246;
+      --accent: 236, 72, 153;
+      --surface: 241, 245, 249;
+      --on-surface: 15, 23, 42;
+      --card: 255, 255, 255;
+      --border: 229, 231, 235;
+    }
+
+    .dark {
+      --primary: 129, 140, 248;
+      --secondary: 167, 139, 250;
+      --accent: 244, 114, 182;
+      --surface: 15, 23, 42;
+      --on-surface: 241, 245, 249;
+      --card: 30, 41, 59;
+      --border: 55, 65, 81;
+    }
+    
+    /* Masonry 布局 */
+    .masonry {
+      column-count: 4;
+      column-gap: 1rem;
+    }
+    @media (max-width: 1024px) {
       .masonry {
-        column-count: 3;
-        column-gap: 1rem;
+        column-count: 2;
       }
-      @media (max-width: 1024px) {
-        .masonry {
-          column-count: 2;
+    }
+    @media (max-width: 640px) {
+      .masonry {
+        column-count: 1;
+      }
+    }
+    .masonry-item {
+      break-inside: avoid;
+      margin-bottom: 1rem;
+    }
+    .sidebar-link {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0.5rem;
+      border-radius: 0.375rem;
+      color: #6b7280;
+      transition:
+        background-color 0.2s,
+        color 0.2s;
+    }
+    .sidebar-link:hover {
+      background-color: #f1f5f9;
+      color: #111827;
+    }
+    nav.mobile #homeBtn {
+      display: none;
+    }
+    nav.mobile {
+      top: auto;
+      bottom: 0;
+      left: 0;
+      height: 72px;
+      width: 100%;
+      flex-direction: row;
+      border-right: none;
+      border-top: 1px solid #e5e7eb;
+    }
+    nav.mobile .sidebar-link {
+      flex: 1;
+      margin-top: 5px;
+    }
+    nav.mobile .sidebar-items {
+      flex-direction: row;
+      width: 100%;
+    }
+    nav.mobile .sidebar-items > * {
+      margin: 0;
+      flex: 1;
+      --tw-space-y-reverse: 0;
+      margin-top: 0;
+      margin-bottom: calc(1.5rem * var(--tw-space-y-reverse));
+    }
+    .notify-dot {
+      position: absolute;
+      top: 4px;
+      right: 4px;
+      width: 0.5rem;
+      height: 0.5rem;
+      background-color: #ef4444;
+      border-radius: 9999px;
+    }
+    nav.mobile .notify-dot {
+      right: 2rem;
+    }
+    /* 弹窗文章样式美化 */
+    #articleModal > div {
+      box-shadow: 0 10px 25px rgb(0 0 0 / 0.2);
+      background-color: rgb(var(--card)); 
+      color: rgb(var(--on-surface)); 
+    }
+    #articleContent img {
+      width: 100%;
+      object-fit: cover;
+      aspect-ratio: 16/9;
+      border-radius: 0.5rem;
+      margin-top: 1rem;
+      margin-bottom: 1rem;
+      color: rgb(var(--on-surface)); 
+    }
+    #articleContent h1,
+    #articleContent h2,
+    #articleContent h3 {
+      margin-top: 1.25rem;
+      font-weight: 600;
+      color: rgb(var(--on-surface)); 
+    }
+    #articleContent p {
+      line-height: 1.7;
+      margin-bottom: 1rem;
+      color: rgb(var(--on-surface)/0.9);
+    }
+    #closeArticle {
+      color: rgb(var(--on-surface)/0.7); 
+    }
+    
+    #closeArticle:hover {
+      color: rgb(var(--primary)); 
+    }
+    p {
+      text-align: justify;
+      text-justify: inter-ideograph;
+    }
+    .spinner {
+      border: 4px solid #e5e7eb;
+      border-top-color: #3b82f6;
+      border-radius: 50%;
+      width: 2rem;
+      height: 2rem;
+      animation: spin 1s linear infinite;
+    }
+    @keyframes spin {
+      to {
+        transform: rotate(360deg);
+      }
+    }
+
+    #articleModal > div,
+    #settingsPanel > div {
+      transform: scale(0.9);
+      opacity: 0;
+      transition: transform 0.2s, opacity 0.2s;
+    }
+
+    #articleModal.show > div,
+    #settingsPanel.show > div {
+      animation: modalZoom 0.2s forwards;
+    }
+
+    @keyframes modalZoom {
+      from {
+        transform: scale(0.9);
+        opacity: 0;
+      }
+      to {
+        transform: scale(1);
+        opacity: 1;
+      }
+    }
+    /* 侧边栏适配深色模式 */
+    nav {
+      background-color: rgb(var(--card));
+      border-color: rgb(var(--border));
+    }
+    
+    .sidebar-link {
+      color: rgb(var(--on-surface)/0.7);
+    }
+    
+    .sidebar-link:hover {
+      background-color: rgb(var(--primary)/0.1);
+      color: rgb(var(--primary));
+    }
+    
+    /* 文字卡片适配深色模式 */
+    .masonry-item .card-content {
+      background-color: rgb(var(--card));
+      color: rgb(var(--on-surface));
+    }
+    
+    .masonry-item .card-content h2 {
+      color: rgb(var(--on-surface));
+    }
+
+    .masonry-item .card-content p {
+      color: rgb(var(--on-surface)/0.8);
+    }
+
+    .masonry-item {
+      background-color: rgb(var(--card));
+      color: rgb(var(--on-surface));
+    }
+    
+    .masonry-item h2 {
+      color: rgb(var(--on-surface));
+    }
+    
+    .masonry-item p {
+      color: rgb(var(--on-surface)/0.8);
+    }
+    
+    .masonry-item a {
+      color: rgb(var(--on-surface)/0.6);
+    }
+    
+    .masonry-item a:hover {
+      color: rgb(var(--primary));
+    }
+    
+    /* 文章弹窗适配深色模式 */
+    #articleContent {
+      color: rgb(var(--on-surface));
+    }
+    
+    #articleContent h1,
+    #articleContent h2,
+    #articleContent h3 {
+      color: rgb(var(--on-surface));
+    }
+    
+    #articleContent p {
+      color: rgb(var(--on-surface)/0.9);
+    }
+    
+    /* 设置面板适配深色模式 */
+    #settingsPanel > div {
+      background-color: rgb(var(--card));
+      color: rgb(var(--on-surface));
+    }
+    
+    #settingsPanel label {
+      color: rgb(var(--on-surface)/0.9);
+    }
+    
+    #settingsPanel input {
+      background-color: rgb(var(--surface));
+      color: rgb(var(--on-surface));
+      border-color: rgb(var(--border));
+    }
+    
+    /* 加载按钮适配深色模式 */
+    #loadMore {
+      background-color: rgb(var(--surface));
+      color: rgb(var(--on-surface));
+    }
+    
+    #loadMore:hover {
+      background-color: rgb(var(--primary));
+      color: white;
+    }
+    
+    /* 分类标签样式 */
+    .category-tag {
+      display: inline-block;
+      padding: 0.25rem 0.5rem;
+      border-radius: 0.25rem;
+      font-size: 0.75rem;
+      font-weight: 500;
+      margin-right: 0.5rem;
+      margin-bottom: 0.5rem;
+    }
+    
+    .category-book {
+      background-color: rgba(59, 130, 246, 0.1);
+      color: rgb(59, 130, 246);
+    }
+    
+    .category-movie {
+      background-color: rgba(139, 92, 246, 0.1);
+      color: rgb(139, 92, 246);
+    }
+    
+    .category-music {
+      background-color: rgba(236, 72, 153, 0.1);
+      color: rgb(236, 72, 153);
+    }
+    
+    .item-type {
+      font-size: 0.875rem;
+      color: rgba(var(--on-surface), 0.7);
+      display: flex;
+      align-items: center;
+      gap: 0.25rem;
+      margin-top: 0.25rem;
+    }
+    
+    .item-type svg {
+      width: 1rem;
+      height: 1rem;
+    }
+    
+    .rss-header {
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+      margin-bottom: 1.5rem;
+    }
+    
+    .rss-avatar {
+      width: 3.5rem;
+      height: 3.5rem;
+      border-radius: 50%;
+      background-color: rgb(var(--primary)/0.1);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: rgb(var(--primary));
+      font-size: 1.5rem;
+      font-weight: bold;
+    }
+    
+    .rss-info h2 {
+      font-size: 1.5rem;
+      font-weight: 700;
+      margin-bottom: 0.25rem;
+    }
+    
+    .rss-info p {
+      color: rgba(var(--on-surface), 0.7);
+      margin-bottom: 0;
+    }
+  </style>
+  <script>
+    // 在tailwind配置前设置darkMode
+    tailwind.config = {
+      darkMode: 'class',
+      theme: {
+        extend: {
+          colors: {
+            primary: 'rgb(var(--primary))',
+            secondary: 'rgb(var(--secondary))',
+            accent: 'rgb(var(--accent))',
+            surface: 'rgb(var(--surface))',
+            'on-surface': 'rgb(var(--on-surface))',
+            card: 'rgb(var(--card))',
+            border: 'rgb(var(--border))'
+          }
         }
       }
-      @media (max-width: 640px) {
-        .masonry {
-          column-count: 1;
-        }
-      }
-      .masonry-item {
-        break-inside: avoid;
-        margin-bottom: 1rem;
-      }
-      .sidebar-link {
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        padding: 0.5rem;
-        border-radius: 0.375rem;
-        color: #6b7280;
-        transition:
-          background-color 0.2s,
-          color 0.2s;
-      }
-      .sidebar-link:hover {
-        background-color: #f1f5f9;
-        color: #111827;
-      }
-    </style>
-    <script>
-      tailwind.config = {
-        darkMode: "class",
-        theme: {
-          extend: {
-            colors: {
-              primary: "rgb(var(--primary))",
-              secondary: "rgb(var(--secondary))",
-              accent: "rgb(var(--accent))",
-              surface: "rgb(var(--surface))",
-              "on-surface": "rgb(var(--on-surface))",
-              card: "rgb(var(--card))",
-              border: "rgb(var(--border))",
-            },
-          },
-        },
-      };
-    </script>
-  </head>
-  <body class="bg-surface text-on-surface min-h-screen font-sans">
-    <nav
-      class="fixed top-0 left-0 h-screen w-[72px] border-r shadow flex flex-col items-center py-4"
+    }
+  </script>
+</head>
+<body class="bg-surface text-on-surface min-h-screen font-sans">
+  <nav class="fixed top-0 left-0 h-screen w-[72px] border-r shadow flex flex-col items-center py-4">
+    <div class="sidebar-items flex flex-col items-center gap-y-6 h-full w-full">
+      <a href="/#" aria-label="主页" class="sidebar-link">
+        <svg viewBox="0 0 24 24" fill="currentColor" class="w-6 h-6">
+          <path d="M7.54 23.15q-.2-2.05.26-3.93L9 14.04a7 7 0 0 1-.35-2.07c0-1.68.81-2.88 2.09-2.88.88 0 1.53.62 1.53 1.8q0 .57-.23 1.28l-.52 1.72q-.15.5-.15.92c0 1.2.91 1.87 2.08 1.87 2.09 0 3.57-2.16 3.57-4.96 0-3.12-2.04-5.12-5.05-5.12-3.36 0-5.49 2.19-5.49 5.24 0 1.22.38 2.36 1.11 3.14-.24.41-.5.48-.88.48-1.2 0-2.34-1.69-2.34-4 0-4 3.2-7.17 7.68-7.17 4.7 0 7.66 3.29 7.66 7.33s-2.88 7.15-5.98 7.15a3.8 3.8 0 0 1-3.06-1.48l-.62 2.5a11 11 0 0 1-1.62 3.67A11.98 11.98 0 0 0 24 12a11.99 11.99 0 1 0-24 0 12 12 0 0 0 7.54 11.15" />
+        </svg>
+      </a>
+      <a href="/" aria-label="首页" class="sidebar-link" id="homeBtn">
+        <svg viewBox="0 0 24 24" fill="currentColor" class="w-6 h-6">
+          <path d="M4.6 22.73A107 107 0 0 0 11 23h2.22c2.43-.04 4.6-.16 6.18-.27A3.9 3.9 0 0 0 23 18.8v-8.46a4 4 0 0 0-1.34-3L14.4.93a3.63 3.63 0 0 0-4.82 0L2.34 7.36A4 4 0 0 0 1 10.35v8.46a3.9 3.9 0 0 0 3.6 3.92M13.08 2.4l7.25 6.44a2 2 0 0 1 .67 1.5v8.46a1.9 1.9 0 0 1-1.74 1.92q-1.39.11-3.26.19V16a4 4 0 0 0-8 0v4.92q-1.87-.08-3.26-.19A1.9 1.9 0 0 1 3 18.81v-8.46a2 2 0 0 1 .67-1.5l7.25-6.44a1.63 1.63 0 0 1 2.16 0M13.12 21h-2.24a1 1 0 0 1-.88-1v-4a2 2 0 1 1 4 0v4a1 1 0 0 1-.88 1" />
+        </svg>
+      </a>
+      <a href="/ideas" aria-label="探索" id="idealBtn" class="sidebar-link">
+        <svg viewBox="0 0 24 24" fill="currentColor" class="w-6 h-6">
+          <path d="M12 14a2 2 0 1 0 0-4 2 2 0 0 0 0 4M9.42 7.24a3 3 0 0 0-2.18 2.18L5.7 15.57a2.25 2.25 0 0 0 2.73 2.73l6.15-1.54a3 3 0 0 0 2.18-2.18l1.54-6.15a2.25 2.25 0 0 0-2.73-2.73zm6.94.7-1.54 6.15a1 1 0 0 1-.73.73l-6.15 1.54a.25.25 0 0 1-.3-.3L9.18 9.9a1 1 0 0 1 .73-.73l6.15-1.54a.25.25 0 0 1 .3.3M12 24a12 12 0 1 0 0-24 12 12 0 0 0 0 24M2 12a10 10 0 1 1 20 0 10 10 0 0 1-20 0" />
+        </svg>
+      </a>
+      <a href="/add/" aria-label="创建" id="addBtn" class="sidebar-link">
+        <svg viewBox="0 0 24 24" fill="currentColor" class="w-6 h-6">
+          <path d="M11 11H6v2h5v5h2v-5h5v-2h-5V6h-2zM5 1a4 4 0 0 0-4 4v14a4 4 0 0 0 4 4h14a4 4 0 0 0 4-4V5a4 4 0 0 0-4-4zm16 4v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5c0-1.1.9-2 2-2h14a2 2 0 0 1 2 2" />
+        </svg>
+      </a>
+      <a href="#" aria-label="更多" id="moreBtn" class="sidebar-link mt-auto">
+        <svg viewBox="0 0 24 24" fill="currentColor" class="w-6 h-6">
+          <path d="M12 7a5 5 0 1 0 0 10 5 5 0 0 0 0-10m3 5a3 3 0 1 1-6 0 3 3 0 0 1 6 0" />
+          <path d="M12 7a5 5 0 1 0 0 10 5 5 0 0 0 0-10m3 5a3 3 0 1 1-6 0 3 3 0 0 1 6 0m1.13-10.29A2 2 0 0 0 14.7.31a12 12 0 0 0-5.4 0c-.73.17-1.26.74-1.43 1.4l-.58 2.14-2.14-.57a2 2 0 0 0-1.93.54 12 12 0 0 0-2.7 4.67c-.22.72.01 1.46.5 1.95L2.59 12l-1.57 1.56a2 2 0 0 0-.5 1.95 12 12 0 0 0 2.7 4.68c.51.54 1.27.72 1.93.54l2.14-.58.58 2.14c.17.67.7 1.24 1.43 1.4a12 12 0 0 0 5.4 0 2 2 0 0 0 1.43-1.4l.58-2.14 2.13.58c.67.18 1.43 0 1.94-.55a12 12 0 0 0 2.7-4.67 2 2 0 0 0-.5-1.94L21.4 12l1.57-1.56c.49-.5.71-1.23.5-1.95a12 12 0 0 0-2.7-4.67 2 2 0 0 0-1.93-.54l-2.14.57zm-6.34.54a10 10 0 0 1 4.42 0l.56 2.12a2 2 0 0 0 2.45 1.41l2.13-.57a10 10 0 0 1 2.2 3.83L20 10.59a2 2 0 0 0 0 2.83l1.55 1.55a10 10 0 0 1-2.2 3.82l-2.13-.57a2 2 0 0 0-2.44 1.42l-.57 2.12a10 10 0 0 1-4.42 0l-.57-2.12a2 2 0 0 0-2.45-1.42l-2.12.57a10 10 0 0 1-2.2-3.82L4 13.42a2 2 0 0 0 0-2.83L2.45 9.03a10 10 0 0 1 2.2-3.82l2.13.57a2 2 0 0 0 2.44-1.41z" />
+        </svg>
+      </a>
+    </div>
+  </nav>
+  <div id="content" class="ml-[72px]">
+    <header class="py-6 px-4 max-w-screen-xl mx-auto">
+      <div class="rss-header">
+        <div class="rss-avatar">金</div>
+        <div class="rss-info">
+          <h1 class="text-3xl font-bold tracking-tight text-on-surface">
+            金桔猪的收藏
+          </h1>
+          <p>想看、在看和看过的书和电影，想听、在听和听过的音乐</p>
+        </div>
+      </div>
+    </header>
+
+    <main class="px-4 max-w-screen-xl mx-auto">
+      <!-- Masonry 容器 -->
+      <div class="masonry" id="gallery"></div>
+      <button
+        id="loadMore"
+        class="mt-4 mx-auto block px-4 py-2 rounded bg-gray-200 text-gray-700 hidden"
+      >
+        加载更多
+      </button>
+    </main>
+
+    <!-- 设置面板 -->
+    <div
+      id="settingsPanel"
+      class="fixed inset-0 bg-black/50 hidden items-center justify-center"
+    >
+      <div class="bg-card rounded-xl p-4 w-72 space-y-3">
+        <div class="flex justify-between items-center">
+          <h2 class="font-semibold">设置</h2>
+          <button id="closeSettings" class="text-xl leading-none">
+            &times;
+          </button>
+        </div>
+        
+        <!-- 深色模式切换器 -->
+        <div class="flex items-center justify-between py-1">
+          <label class="text-sm">深色模式</label>
+          <label class="relative inline-flex items-center cursor-pointer">
+            <input type="checkbox" id="darkModeToggle" class="sr-only peer">
+            <div class="w-11 h-6 bg-gray-200 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-primary"></div>
+          </label>
+        </div>
+        
+        <label class="block text-sm"
+          >列数
+          <input
+            id="columnCountInput"
+            type="number"
+            min="1"
+            max="6"
+            value="4"
+            class="mt-1 w-full border rounded p-1 bg-surface text-on-surface"
+          />
+        </label>
+        <label class="block text-sm"
+          >加载卡片数量
+          <input
+            id="perPageInput"
+            type="number"
+            min="1"
+            value="30"
+            class="mt-1 w-full border rounded p-1 bg-surface text-on-surface"
+          />
+        </label>
+        <button id="applySettings" class="w-full bg-primary text-white py-1 rounded">应用</button>
+        <button id="clearCache" class="w-full bg-red-500 text-white py-1 rounded">清理缓存</button> 
+        <footer class="text-xs text-center text-gray-400 my-4">
+          <a href="#" class="hover:underline">查看项目源码</a> · <a href="#">联系我吧</a>
+        </footer>
+      </div>
+    </div>
+
+    <!-- 文章弹窗 -->
+    <div
+      id="articleModal"
+      class="fixed inset-0 bg-black/50 hidden items-center justify-center"
     >
       <div
-        class="sidebar-items flex flex-col items-center gap-y-6 h-full w-full"
+        class="rounded-xl w-11/12 max-w-3xl h-[80vh] overflow-auto relative p-4"
       >
-        <a href="/#" aria-label="主页" class="sidebar-link">
-          <svg viewBox="0 0 24 24" fill="currentColor" class="w-6 h-6">
-            <path
-              d="M7.54 23.15q-.2-2.05.26-3.93L9 14.04a7 7 0 0 1-.35-2.07c0-1.68.81-2.88 2.09-2.88.88 0 1.53.62 1.53 1.8q0 .57-.23 1.28l-.52 1.72q-.15.5-.15.92c0 1.2.91 1.87 2.08 1.87 2.09 0 3.57-2.16 3.57-4.96 0-3.12-2.04-5.12-5.05-5.12-3.36 0-5.49 2.19-5.49 5.24 0 1.22.38 2.36 1.11 3.14-.24.41-.5.48-.88.48-1.2 0-2.34-1.69-2.34-4 0-4 3.2-7.17 7.68-7.17 4.7 0 7.66 3.29 7.66 7.33s-2.88 7.15-5.98 7.15a3.8 3.8 0 0 1-3.06-1.48l-.62 2.5a11 11 0 0 1-1.62 3.67A11.98 11.98 0 0 0 24 12a11.99 11.99 0 1 0-24 0 12 12 0 0 0 7.54 11.15"
-            />
-          </svg>
-        </a>
-        <a href="/" aria-label="首页" class="sidebar-link" id="homeBtn">
-          <svg viewBox="0 0 24 24" fill="currentColor" class="w-6 h-6">
-            <path
-              d="M4.6 22.73A107 107 0 0 0 11 23h2.22c2.43-.04 4.6-.16 6.18-.27A3.9 3.9 0 0 0 23 18.8v-8.46a4 4 0 0 0-1.34-3L14.4.93a3.63 3.63 0 0 0-4.82 0L2.34 7.36A4 4 0 0 0 1 10.35v8.46a3.9 3.9 0 0 0 3.6 3.92M13.08 2.4l7.25 6.44a2 2 0 0 1 .67 1.5v8.46a1.9 1.9 0 0 1-1.74 1.92q-1.39.11-3.26.19V16a4 4 0 0 0-8 0v4.92q-1.87-.08-3.26-.19A1.9 1.9 0 0 1 3 18.81v-8.46a2 2 0 0 1 .67-1.5l7.25-6.44a1.63 1.63 0 0 1 2.16 0M13.12 21h-2.24a1 1 0 0 1-.88-1v-4a2 2 0 1 1 4 0v4a1 1 0 0 1-.88 1"
-            />
-          </svg>
-        </a>
-        <a href="/ideas" aria-label="探索" id="idealBtn" class="sidebar-link">
-          <svg viewBox="0 0 24 24" fill="currentColor" class="w-6 h-6">
-            <path
-              d="M12 14a2 2 0 1 0 0-4 2 2 0 0 0 0 4M9.42 7.24a3 3 0 0 0-2.18 2.18L5.7 15.57a2.25 2.25 0 0 0 2.73 2.73l6.15-1.54a3 3 0 0 0 2.18-2.18l1.54-6.15a2.25 2.25 0 0 0-2.73-2.73zm6.94.7-1.54 6.15a1 1 0 0 1-.73.73l-6.15 1.54a.25.25 0 0 1-.3-.3L9.18 9.9a1 1 0 0 1 .73-.73l6.15-1.54a.25.25 0 0 1 .3.3M12 24a12 12 0 1 0 0-24 12 12 0 0 0 0 24M2 12a10 10 0 1 1 20 0 10 10 0 0 1-20 0"
-            />
-          </svg>
-        </a>
-        <a href="/add" aria-label="创建" id="addBtn" class="sidebar-link">
-          <svg viewBox="0 0 24 24" fill="currentColor" class="w-6 h-6">
-            <path
-              d="M11 11H6v2h5v5h2v-5h5v-2h-5V6h-2zM5 1a4 4 0 0 0-4 4v14a4 4 0 0 0 4 4h14a4 4 0 0 0 4-4V5a4 4 0 0 0-4-4zm16 4v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5c0-1.1.9-2 2-2h14a2 2 0 0 1 2 2"
-            />
-          </svg>
-        </a>
+        <button id="closeArticle" class="absolute top-2 right-4 text-2xl">
+          &times;
+        </button>
+        <div id="articleContent" class="prose max-w-none"></div>
       </div>
-    </nav>
-    <div id="content" class="ml-[72px]">
-      <header class="py-6 text-center">
-        <h1 class="text-3xl font-bold tracking-tight text-on-surface">
-          RSS 阅读器
-        </h1>
-      </header>
-      <main class="px-4 max-w-screen-xl mx-auto">
-        <div class="masonry" id="feedList"></div>
-      </main>
     </div>
+
     <script>
-      document.addEventListener("DOMContentLoaded", async () => {
-        const feedList = document.getElementById("feedList");
-        const defaults = Array.isArray(window.DEFAULT_FEEDS)
-          ? window.DEFAULT_FEEDS
-          : [];
-        const preloaded = Array.isArray(window.PRELOAD_ITEMS)
-          ? window.PRELOAD_ITEMS
-          : [];
-        const extra = (localStorage.getItem("rssFeeds") || "")
-          .split(/\r?\n|,/)
-          .map((s) => s.trim())
-          .filter(Boolean)
-          .filter((u) => !defaults.includes(u));
+      document.addEventListener("DOMContentLoaded", () => {
+        // 初始化深色模式
+        const darkModeToggle = document.getElementById('darkModeToggle');
+        const isDarkMode = localStorage.getItem('darkMode') === 'true' || 
+                          (window.matchMedia('(prefers-color-scheme: dark)').matches && 
+                          localStorage.getItem('darkMode') !== 'false');
+        
+        if (isDarkMode) {
+          document.documentElement.classList.add('dark');
+          darkModeToggle.checked = true;
+        }
+        
+        darkModeToggle.addEventListener('change', () => {
+          if (darkModeToggle.checked) {
+            document.documentElement.classList.add('dark');
+            localStorage.setItem('darkMode', 'true');
+          } else {
+            document.documentElement.classList.remove('dark');
+            localStorage.setItem('darkMode', 'false');
+          }
+        });
 
-        function render(items) {
-          for (const it of items) {
-            const card = document.createElement("div");
-            card.className = "masonry-item rounded-2xl shadow bg-card p-4";
-            const title = document.createElement("h2");
-            title.className = "text-lg font-semibold mb-2";
-            title.textContent = it.title;
-            const desc = document.createElement("p");
-            desc.className = "text-sm text-gray-600 mb-2";
-            desc.innerHTML = it.description;
-            const link = document.createElement("a");
-            link.href = it.link;
-            link.target = "_blank";
-            link.className = "text-xs text-gray-400 hover:underline self-end";
-            link.textContent = "查看原文";
-            card.appendChild(title);
-            card.appendChild(desc);
-            card.appendChild(link);
-            feedList.appendChild(card);
+        const gallery = document.getElementById("gallery");
+        const loadMoreBtn = document.getElementById("loadMore");
+        const settingsPanel = document.getElementById("settingsPanel");
+        const moreBtn = document.getElementById("moreBtn");
+        const closeSettings = document.getElementById("closeSettings");
+        const applySettings = document.getElementById("applySettings");
+        const columnCountInput = document.getElementById("columnCountInput");
+        const perPageInput = document.getElementById("perPageInput");
+        const articleModal = document.getElementById("articleModal");
+        const closeArticle = document.getElementById("closeArticle");
+        const articleContent = document.getElementById("articleContent");
+        const clearCacheBtn = document.getElementById('clearCache');
+        
+        // RSS源数据（模拟豆瓣收藏）
+        const rssData = [
+          {
+            title: "看过阿诺拉",
+            link: "https://movie.douban.com/subject/36195543/",
+            imgSrc: "https://img1.doubanio.com/view/photo/s_ratio_poster/public/p2912764859.webp",
+            creator: "金桔猪",
+            pubDate: "2025-02-21",
+            type: "movie"
+          },
+          {
+            title: "看过新宿野战医院",
+            link: "https://movie.douban.com/subject/36902609/",
+            imgSrc: "https://img1.doubanio.com/view/photo/s_ratio_poster/public/p2909993898.webp",
+            creator: "金桔猪",
+            pubDate: "2024-12-07",
+            type: "movie"
+          },
+          {
+            title: "想看荒野机器人",
+            link: "https://movie.douban.com/subject/36689857/",
+            imgSrc: "https://img2.doubanio.com/view/photo/s_ratio_poster/public/p2913022141.webp",
+            creator: "金桔猪",
+            pubDate: "2024-11-17",
+            type: "movie"
+          },
+          {
+            title: "看过某种物质",
+            link: "https://movie.douban.com/subject/35882838/",
+            imgSrc: "https://img1.doubanio.com/view/photo/s_ratio_poster/public/p2912441039.webp",
+            creator: "金桔猪",
+            pubDate: "2024-11-17",
+            type: "movie"
+          },
+          {
+            title: "看过小妇人",
+            link: "https://movie.douban.com/subject/26348103/",
+            imgSrc: "https://img9.doubanio.com/view/photo/s_ratio_poster/public/p2572928166.webp",
+            creator: "金桔猪",
+            pubDate: "2024-11-12",
+            type: "movie"
+          },
+          {
+            title: "看过他是龙",
+            link: "https://movie.douban.com/subject/26726098/",
+            imgSrc: "https://img2.doubanio.com/view/photo/s_ratio_poster/public/p2374045871.webp",
+            creator: "金桔猪",
+            pubDate: "2024-09-17",
+            type: "movie"
+          },
+          {
+            title: "看过死侍与金刚狼",
+            link: "https://movie.douban.com/subject/26957900/",
+            imgSrc: "https://img9.doubanio.com/view/photo/s_ratio_poster/public/p2908440764.webp",
+            creator: "金桔猪",
+            pubDate: "2024-08-11",
+            type: "movie"
+          },
+          {
+            title: "看过塔罗牌",
+            link: "https://movie.douban.com/subject/36733268/",
+            imgSrc: "https://img3.doubanio.com/view/photo/s_ratio_poster/public/p2911767273.webp",
+            creator: "金桔猪",
+            pubDate: "2024-08-11",
+            type: "movie"
+          },
+          {
+            title: "想读“没话找话”指南",
+            link: "https://book.douban.com/subject/36124823/",
+            imgSrc: "https://img9.doubanio.com/view/subject/s/public/s34330754.jpg",
+            creator: "金桔猪",
+            pubDate: "2024-06-24",
+            type: "book"
+          },
+          {
+            title: "想读日常生活中的非暴力沟通",
+            link: "https://book.douban.com/subject/36506276/",
+            imgSrc: "https://img3.doubanio.com/view/subject/s/public/s34619022.jpg",
+            creator: "金桔猪",
+            pubDate: "2024-06-24",
+            type: "book"
+          },
+          {
+            title: "听过Midnights",
+            link: "https://music.douban.com/subject/36130489/",
+            imgSrc: "https://img9.doubanio.com/view/subject/s/public/s34359738.jpg",
+            creator: "金桔猪",
+            pubDate: "2024-05-15",
+            type: "music"
+          },
+          {
+            title: "听过30",
+            link: "https://music.douban.com/subject/35669718/",
+            imgSrc: "https://img1.doubanio.com/view/subject/s/public/s34036615.jpg",
+            creator: "金桔猪",
+            pubDate: "2024-04-10",
+            type: "music"
+          }
+        ];
+
+        const navEl = document.querySelector("nav");
+        const contentEl = document.getElementById("content");
+        const isMobile = /Mobi|Android|iPhone|Windows Phone/i.test(
+          navigator.userAgent,
+        );
+
+        const savedCols = parseInt(localStorage.getItem("columnCount")) || 4;
+        const savedPerPage = parseInt(localStorage.getItem("perPage")) || 30;
+
+        const initialCols = isMobile ? 2 : savedCols;
+
+        columnCountInput.value = String(initialCols);
+        perPageInput.value = String(savedPerPage);
+        gallery.style.columnCount = String(initialCols);
+
+        if (isMobile) {
+          document.body.classList.add("mobile");
+          navEl.classList.add("mobile");
+          contentEl.classList.remove("ml-[72px]");
+          contentEl.classList.add("mb-[72px]");
+        }
+
+        let allItems = [];
+        let currentPage = 0;
+        let perPage = savedPerPage;
+
+        function getRandomColor() {
+          return (
+            "#" +
+            Math.floor(Math.random() * 0xffffff)
+              .toString(16)
+              .padStart(6, "0")
+          );
+        }
+
+        function createImage(src, alt) {
+          const img = document.createElement("img");
+          img.className =
+            "w-full rounded-t-2xl object-cover hover:opacity-90 transition-opacity aspect-video";
+          img.src = src;
+          img.alt = alt;
+          img.loading = "lazy";
+          const randomHeight = 180 + Math.random() * 120; // 180 - 300px
+          img.style.height = `${randomHeight}px`;
+          img.style.backgroundColor = getRandomColor();
+          img.style.minHeight = "120px";
+          img.style.opacity = "0";
+          img.style.transition = "opacity 0.5s";
+          img.addEventListener("load", () => {
+            img.style.opacity = "1";
+            img.style.backgroundColor = "";
+            img.style.minHeight = "";
+          });
+          return img;
+        }
+
+        function formatDate(dateStr) {
+          const date = new Date(dateStr);
+          return date.toLocaleDateString();
+        }
+
+        function createCard(item) {
+          const wrapper = document.createElement("div");
+          wrapper.className =
+            "masonry-item rounded-2xl shadow overflow-hidden flex flex-col cursor-pointer";
+          wrapper.dataset.url = item.link;
+
+          if (item.imgSrc) {
+            const img = createImage(item.imgSrc, item.title);
+            wrapper.appendChild(img);
+          }
+
+          const text = document.createElement("div");
+          text.className = "card-content p-5 flex flex-col gap-2";
+
+          const h2 = document.createElement("h2");
+          h2.className = "text-xl font-semibold text-slate-900 tracking-tight mb-1";
+          h2.textContent = item.title;
+          
+          // 添加分类标签
+          const category = document.createElement("div");
+          category.className = "flex flex-wrap";
+          
+          let categoryClass = "category-movie";
+          let categoryText = "电影";
+          
+          if (item.type === "book") {
+            categoryClass = "category-book";
+            categoryText = "书籍";
+          } else if (item.type === "music") {
+            categoryClass = "category-music";
+            categoryText = "音乐";
+          }
+          
+          const categorySpan = document.createElement("span");
+          categorySpan.className = `category-tag ${categoryClass}`;
+          categorySpan.textContent = categoryText;
+          category.appendChild(categorySpan);
+          text.appendChild(category);
+
+          const p = document.createElement("p");
+          p.className = "text-sm text-gray-600 leading-relaxed mb-2";
+          p.textContent = `${item.creator} · ${formatDate(item.pubDate)}`;
+
+          const link = document.createElement("a");
+          link.className =
+            "text-xs text-gray-400 hover:underline self-end";
+          link.textContent = "查看原文";
+          link.href = item.link;
+          link.target = "_blank";
+          link.rel = "noopener noreferrer";
+          link.addEventListener("click", (e) => e.stopPropagation());
+
+          text.appendChild(h2);
+          text.appendChild(p);
+          text.appendChild(link);
+          wrapper.appendChild(text);
+
+          wrapper.addEventListener("click", async () => {
+            const url = wrapper.dataset.url;
+            if (!url) return;
+            const key = "article:" + url;
+            let html = localStorage.getItem(key);
+            if (!html) {
+              showLoading();
+              try {
+                // 模拟获取文章内容
+                await new Promise(resolve => setTimeout(resolve, 800));
+                html = `
+                  <div class="prose max-w-none">
+                    <h1>${item.title}</h1>
+                    <p class="text-gray-600">作者: ${item.creator} | 发布日期: ${item.pubDate}</p>
+                    <p>这是关于${item.title}的详细介绍。此处展示该条目的详细信息，包括简介、评论等内容。</p>
+                    <p>${item.title}是一部非常优秀的作品，获得了观众的一致好评。</p>
+                    <p>豆瓣评分: <span class="font-bold">8.5</span>/10</p>
+                    <p>更多信息请访问 <a href="${item.link}" target="_blank" class="text-blue-500 hover:underline">原文链接</a>。</p>
+                  </div>
+                `;
+                localStorage.setItem(key, html);
+              } catch (err) {
+                html = "<p>加载失败</p>";
+              }
+            }
+            showArticle(html);
+          });
+
+          return wrapper;
+        }
+
+        function showArticle(html) {
+          articleContent.innerHTML = html;
+          articleModal.classList.remove("hidden");
+          articleModal.classList.add("flex", "show");
+          const content = document.getElementById('articleContent');
+          content.classList.add('dark:prose-invert');
+        }
+
+        function showLoading() {
+          articleContent.innerHTML =
+            '<div class="h-40 flex items-center justify-center"><div class="spinner"></div></div>';
+          articleModal.classList.remove("hidden");
+          articleModal.classList.add("flex", "show");
+        }
+
+        function hideArticle() {
+          articleModal.classList.add("hidden");
+          articleModal.classList.remove("flex", "show");
+          articleContent.innerHTML = "";
+        }
+
+        function renderPage() {
+          gallery.innerHTML = "";
+          const end = (currentPage + 1) * perPage;
+          const items = allItems.slice(0, end);
+          items.forEach((item) => {
+            gallery.appendChild(createCard(item));
+          });
+          if (end >= allItems.length) {
+            loadMoreBtn.classList.add("hidden");
+          } else {
+            loadMoreBtn.classList.remove("hidden");
           }
         }
 
-        render(preloaded);
-
-        async function load(url) {
-          const res = await fetch("/api/rss?url=" + encodeURIComponent(url));
-          if (!res.ok) throw new Error("fail");
-          return (await res.json()).items || [];
+        function initGallery() {
+          allItems = rssData;
+          currentPage = 0;
+          renderPage();
         }
 
-        for (const url of extra) {
-          try {
-            const items = await load(url);
-            render(items);
-          } catch (e) {
-            console.error(e);
+        loadMoreBtn.addEventListener("click", () => {
+          currentPage++;
+          renderPage();
+        });
+
+        moreBtn.addEventListener("click", (e) => {
+          e.preventDefault();
+          settingsPanel.classList.remove("hidden");
+          settingsPanel.classList.add("flex", "show");
+        });
+
+        closeSettings.addEventListener("click", () => {
+          settingsPanel.classList.add("hidden");
+          settingsPanel.classList.remove("flex", "show");
+        });
+
+        closeArticle.addEventListener("click", hideArticle);
+        articleModal.addEventListener("click", (e) => {
+          if (e.target === articleModal) hideArticle();
+        });
+
+        applySettings.addEventListener('click', () => {
+          const cols = Math.max(1, parseInt(columnCountInput.value) || 1);
+          perPage = Math.max(1, parseInt(perPageInput.value) || 1);
+          gallery.style.columnCount = String(cols);
+          localStorage.setItem('columnCount', String(cols));
+          localStorage.setItem('perPage', String(perPage));
+          currentPage = 0;
+          renderPage();
+          settingsPanel.classList.add('hidden');
+          settingsPanel.classList.remove('flex', 'show');
+        });
+
+        clearCacheBtn.addEventListener('click', async () => {
+          // 清除本地存储
+          const keys = Object.keys(localStorage).filter(key => key.startsWith('article:'));
+          keys.forEach(key => localStorage.removeItem(key));
+          
+          // 清除缓存
+          if ('caches' in window) {
+            const names = await caches.keys();
+            await Promise.all(names.map((n) => caches.delete(n)));
           }
-        }
+          
+          // 重新加载数据
+          currentPage = 0;
+          renderPage();
+        });
+
+        // 初始化页面
+        initGallery();
       });
     </script>
-  </body>
+  </div>
+</body>
 </html>

--- a/add.html
+++ b/add.html
@@ -549,8 +549,6 @@ return parseRSS(text);
 
 }
 
-function parseRSS(text) {
-
 const parser = new DOMParser();
 
 const xmlDoc = parser.parseFromString(text, "text/xml");

--- a/admin.html
+++ b/admin.html
@@ -12,10 +12,14 @@
       <label class="block mb-1 font-semibold" for="apiInput">API 域名</label>
       <textarea id="apiInput" placeholder="https://a.com" class="border p-2 w-full h-24"></textarea>
     </div>
-    <div class="mb-4">
-      <label class="block mb-1 font-semibold" for="imgInput">图片域名</label>
-      <textarea id="imgInput" placeholder="https://img.com" class="border p-2 w-full h-24"></textarea>
-    </div>
+  <div class="mb-4">
+    <label class="block mb-1 font-semibold" for="imgInput">图片域名</label>
+    <textarea id="imgInput" placeholder="https://img.com" class="border p-2 w-full h-24"></textarea>
+  </div>
+  <div class="mb-4">
+    <label class="block mb-1 font-semibold" for="rssInput">RSS 源 (一行一个)</label>
+    <textarea id="rssInput" placeholder="https://example.com/feed" class="border p-2 w-full h-24"></textarea>
+  </div>
     <button id="saveBtn" class="bg-blue-500 text-white px-4 py-2 rounded">保存</button>
     <div class="mt-8">
       <h2 class="text-lg font-semibold mb-2">缓存信息</h2>
@@ -33,12 +37,15 @@
     <script>
       const apiInput = document.getElementById('apiInput');
       const imgInput = document.getElementById('imgInput');
+      const rssInput = document.getElementById('rssInput');
       const sortSelect = document.getElementById('sortSelect');
       apiInput.value = localStorage.getItem('apiDomains') || localStorage.getItem('apiDomain') || '';
       imgInput.value = localStorage.getItem('imgDomains') || '';
+      rssInput.value = localStorage.getItem('rssFeeds') || '';
       document.getElementById('saveBtn').addEventListener('click', () => {
         localStorage.setItem('apiDomains', apiInput.value.trim());
         localStorage.setItem('imgDomains', imgInput.value.trim());
+        localStorage.setItem('rssFeeds', rssInput.value.trim());
         localStorage.removeItem('apiDomain');
         alert('已保存');
       });

--- a/server.ts
+++ b/server.ts
@@ -30,11 +30,13 @@ const imgDomains = imgDomainsEnv
   .split(/[,\s]+/)
   .map((d) => d.trim())
   .filter(Boolean);
+const rssEnv = Deno.env.get("RSS_URLS") || "";
+const rssUrls = rssEnv.split(/[,\s]+/).map((d) => d.trim()).filter(Boolean);
 const cacheImgDomain = Deno.env.get("IMG_CACHE") || "";
 
 function injectConfig(html: string): string {
-  if (apiDomains.length === 0 && imgDomains.length === 0) return html;
-  const script = `<script>window.API_DOMAINS=${JSON.stringify(apiDomains)};window.IMG_DOMAINS=${JSON.stringify(imgDomains)};</script>`;
+  if (apiDomains.length === 0 && imgDomains.length === 0 && rssUrls.length === 0) return html;
+  const script = `<script>window.API_DOMAINS=${JSON.stringify(apiDomains)};window.IMG_DOMAINS=${JSON.stringify(imgDomains)};window.DEFAULT_FEEDS=${JSON.stringify(rssUrls)};</script>`;
   return html.replace("</head>", `${script}</head>`);
 }
 
@@ -48,6 +50,9 @@ const swRaw = await Deno.readTextFile(join(__dirname, "sw.js"));
 const swHtml = `const IMG_CACHE = ${JSON.stringify(cacheImgDomain)};\n${swRaw}`;
 const adminHtml = injectConfig(
   await Deno.readTextFile(join(__dirname, "admin.html")),
+);
+const addHtml = injectConfig(
+  await Deno.readTextFile(join(__dirname, "add.html")),
 );
 const fallbackSentences = [
   "小荷才露尖尖角",
@@ -164,6 +169,24 @@ function proxifyHtml(html: string): string {
   });
 
   return $.html();
+}
+
+// ---------- 解析 RSS ----------
+async function fetchRss(url: string) {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  const xml = await res.text();
+  const $ = cheerio.load(xml, { xmlMode: true });
+  const items: { title: string; link: string; description: string; pubDate: string }[] = [];
+  $("item").each((_, el) => {
+    items.push({
+      title: $(el).find("title").text().trim(),
+      link: $(el).find("link").text().trim(),
+      description: $(el).find("description").text().trim(),
+      pubDate: $(el).find("pubDate").text().trim(),
+    });
+  });
+  return items;
 }
 
 // ---------- 反向代理图片 ----------
@@ -294,6 +317,20 @@ async function handler(req: Request): Promise<Response> {
     }
   }
 
+  // /api/rss —— 获取 RSS 并返回 JSON
+  if (pathname === "/api/rss") {
+    const urlParams = searchParams.getAll("url");
+    const list = urlParams.length > 0 ? urlParams : rssUrls;
+    if (list.length === 0) return json({ items: [] });
+    try {
+      const results = await Promise.all(list.map(fetchRss));
+      const items = results.flat();
+      return json({ items });
+    } catch (err) {
+      return json({ error: err.message }, 500);
+    }
+  }
+
   if (pathname === "/sw.js") {
     return new Response(swHtml, {
       headers: withCors({ "Content-Type": "text/javascript; charset=utf-8" }),
@@ -317,6 +354,12 @@ async function handler(req: Request): Promise<Response> {
   // /ideas —— 灵感瀑布流页面
   if (pathname === "/ideas") {
     return new Response(ideasHtml, {
+      headers: withCors({ "Content-Type": "text/html; charset=utf-8" }),
+    });
+  }
+
+  if (pathname === "/add" || pathname === "/add/") {
+    return new Response(addHtml, {
       headers: withCors({ "Content-Type": "text/html; charset=utf-8" }),
     });
   }

--- a/sw.js
+++ b/sw.js
@@ -41,6 +41,10 @@ self.addEventListener("fetch", (event) => {
     event.respondWith(cacheThenNetwork(event.request));
   } else if (url.pathname === "/ideas") {
     event.respondWith(cacheThenNetwork(event.request));
+  } else if (url.pathname === "/add" || url.pathname === "/add/") {
+    event.respondWith(cacheThenNetwork(event.request));
+  } else if (url.pathname === "/api/rss") {
+    event.respondWith(cacheThenNetwork(event.request));
   }
 });
 

--- a/worker.js
+++ b/worker.js
@@ -3,6 +3,7 @@ import * as cheerio from "cheerio";
 import mainHtml from "./main.html";
 import ideasHtml from "./ideas.html";
 import adminHtml from "./admin.html";
+import addHtml from "./add.html";
 // import swHtml from "./sw.js";
 import articleText from "./article.txt";
 
@@ -45,6 +46,8 @@ let urls = [];
 let urlsInit = false;
 let cache = { data: null, timestamp: 0 };
 let dailyCache = { data: null, timestamp: 0 };
+let rssUrls = [];
+let rssInit = false;
 
 async function getUrls(env) {
   if (!urlsInit) {
@@ -65,11 +68,20 @@ async function getUrls(env) {
   return urls;
 }
 
-function injectConfig(html, apiDomains, imgDomains) {
-  if (!apiDomains.length && !imgDomains.length) return html;
+async function getRss(env) {
+  if (!rssInit) {
+    rssInit = true;
+    const envStr = env.RSS_URLS || "";
+    rssUrls = envStr.split(/[,\s]+/).map((s) => s.trim()).filter(Boolean);
+  }
+  return rssUrls;
+}
+
+function injectConfig(html, apiDomains, imgDomains, feeds) {
+  if (!apiDomains.length && !imgDomains.length && !feeds.length) return html;
   const script = `<script>window.API_DOMAINS=${JSON.stringify(
     apiDomains,
-  )};window.IMG_DOMAINS=${JSON.stringify(imgDomains)};</script>`;
+  )};window.IMG_DOMAINS=${JSON.stringify(imgDomains)};window.DEFAULT_FEEDS=${JSON.stringify(feeds)};</script>`;
   return html.replace("</head>", `${script}</head>`);
 }
 
@@ -87,6 +99,23 @@ function proxifyHtml(html) {
     $(el).attr('style', style);
   });
   return $.html();
+}
+
+async function fetchRss(url) {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  const xml = await res.text();
+  const $ = cheerio.load(xml, { xmlMode: true });
+  const items = [];
+  $("item").each((_, el) => {
+    items.push({
+      title: $(el).find("title").text().trim(),
+      link: $(el).find("link").text().trim(),
+      description: $(el).find("description").text().trim(),
+      pubDate: $(el).find("pubDate").text().trim(),
+    });
+  });
+  return items;
 }
 
 async function proxyImage(imgUrl) {
@@ -176,9 +205,11 @@ export default {
       .filter(Boolean);
     const cacheImgDomain = env.IMG_CACHE || "mmbiz.qpic.cn";
 
-    const indexHtml = injectConfig(mainHtml, apiDomains, imgDomains);
-    const ideasPage = injectConfig(ideasHtml, apiDomains, imgDomains);
-    const adminPage = injectConfig(adminHtml, apiDomains, imgDomains);
+    const feeds = await getRss(env);
+    const indexHtml = injectConfig(mainHtml, apiDomains, imgDomains, feeds);
+    const ideasPage = injectConfig(ideasHtml, apiDomains, imgDomains, feeds);
+    const adminPage = injectConfig(adminHtml, apiDomains, imgDomains, feeds);
+    const addPage = injectConfig(addHtml, apiDomains, imgDomains, feeds);
 
     const urls = await getUrls(env);
 
@@ -247,6 +278,19 @@ export default {
           headers: withCors({ "Content-Type": "text/html; charset=utf-8" }),
         });
       } catch (err) {
+      return json({ error: err.message }, 500);
+    }
+    }
+
+    if (pathname === "/api/rss") {
+      const list = searchParams.getAll("url");
+      const feeds = list.length > 0 ? list : await getRss(env);
+      if (feeds.length === 0) return json({ items: [] });
+      try {
+        const results = await Promise.all(feeds.map(fetchRss));
+        const items = results.flat();
+        return json({ items });
+      } catch (err) {
         return json({ error: err.message }, 500);
       }
     }
@@ -296,6 +340,10 @@ self.addEventListener("fetch", (event) => {
   } else if (url.pathname === "/") {
     event.respondWith(cacheThenNetwork(event.request));
   } else if (url.pathname === "/ideas") {
+    event.respondWith(cacheThenNetwork(event.request));
+  } else if (url.pathname === "/add" || url.pathname === "/add/") {
+    event.respondWith(cacheThenNetwork(event.request));
+  } else if (url.pathname === "/api/rss") {
     event.respondWith(cacheThenNetwork(event.request));
   }
 });
@@ -404,6 +452,12 @@ async function cacheThenNetwork(request) {
 
     if (pathname === "/ideas") {
       return new Response(ideasPage, {
+        headers: withCors({ "Content-Type": "text/html; charset=utf-8" }),
+      });
+    }
+
+    if (pathname === "/add" || pathname === "/add/") {
+      return new Response(addPage, {
         headers: withCors({ "Content-Type": "text/html; charset=utf-8" }),
       });
     }


### PR DESCRIPTION
## Summary
- add `add.html` page to display RSS items
- expose default RSS URLs via `RSS_URLS` env
- support `/api/rss` endpoint on Deno server and Worker
- serve `/add` page and update caching logic
- allow admin page to store RSS sources

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68577063ad44832ea18a7f8a6de37f95