### PR TITLE
Add YAML support for article metadata

### DIFF
--- a/article.txt
+++ b/article.txt
@@ -1,4 +1,21 @@
-https://mp.weixin.qq.com/s?__biz=MzA5NzQ4ODg5OA==&tempkey=MTMyN19MSXM4UUljL1k1b0JFQ3l1cDFRZC1ycjB6eVpHT3UzX1pFXzc1QmVRaEdZU2xSYmJFdWU1aVI0TzhoWTk3UDZKalZMMGtCTFVuQi1PaWtjTWtSZzV4Q0RZYUdRRTlkUWVSYlJ1N0hwQ3dYekw4MEFQdWFjV1pqWGQ1YUN6WEd3cHp2ZU5Ua2NYR3dwbGZfYklxZGNONldJQ21qV2k1ejNjZDB6V1Fnfn4%3D&chksm=10a1584027d6d156adbdc5e78ac1c88b1c59eba36c0091f517860b53529a90f76fbc8881a206#rd
-https://mp.weixin.qq.com/s/d-h4lk1eHbUvUV5HOZlb-Q
-https://mp.weixin.qq.com/s/aYyVflT4SDOgeSmUCaPOKg
-https://mp.weixin.qq.com/s/k1b6874lw7QpAnrICSlRpg
+---
+url: https://mp.weixin.qq.com/s?__biz=MzA5NzQ4ODg5OA==&tempkey=MTMyN19MSXM4UUljL1k1b0JFQ3l1cDFRZC1ycjB6eVpHT3UzX1pFXzc1QmVRaEdZU2xSYmJFdWU1aVI0TzhoWTk3UDZKalZMMGtCTFVuQi1PaWtjTWtSZzV4Q0RZYUdRRTlkUWVSYlJ1N0hwQ3dYekw4MEFQdWFjV1pqWGQ1YUN6WEd3cHp2ZU5Ua2NYR3dwbGZfYklxZGNONldJQ21qV2k1ejNjZDB6V1Fnfn4%3D&chksm=10a1584027d6d156adbdc5e78ac1c88b1c59eba36c0091f517860b53529a90f76fbc8881a206#rd
+title: 如果这里有标题则优先使用
+tags:
+  - 日常
+  - 设计
+abbrlink: 1a1a
+describe: 如果此处有描述则优先使用这个描述显示
+date: 2022-02-25 17:24:12
+---
+
+---
+url: https://mp.weixin.qq.com/s/d-h4lk1eHbUvUV5HOZlb-Q
+title:
+tags:
+  - 日常
+  - 设计
+abbrlink: 1a1b
+describe:
+date: 2024-02-25 17:24:12
+---

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "type": "module",
   "dependencies": {
-    "cheerio": "^1.0.0-rc.12"
+    "cheerio": "^1.0.0-rc.12",
+    "yaml": "^2.3.3"
   }
 }


### PR DESCRIPTION
## Summary
- switch `article.txt` to YAML front matter format
- parse article metadata in server and worker
- allow custom titles, descriptions, tags and short links
- add `/a/:abbr` redirect route

## Testing
- `node --check worker.js`

------
https://chatgpt.com/codex/tasks/task_b_6858b01fe758832eae7754b25efb00f0