### PR TITLE
Fix tag highlight and improve tag hover style

### DIFF
--- a/ideas.html
+++ b/ideas.html
@@ -940,13 +940,13 @@
           const searchBtn = document.createElement('button');
           searchBtn.id = 'searchBtn';
           searchBtn.textContent = '🔍︎';
-          searchBtn.className = 'px-3 py-1 rounded-full text-sm border hover:bg-primary/10';
+          searchBtn.className = 'px-3 py-1 rounded-full text-sm border hover:border-primary hover:border-2';
           tagList.appendChild(searchBtn);
           tags.forEach((t) => {
             const btn = document.createElement('button');
             btn.dataset.tag = t;
             btn.textContent = t;
-            btn.className = 'px-3 py-1 rounded-full text-sm border hover:bg-primary/10';
+            btn.className = 'px-3 py-1 rounded-full text-sm border hover:border-primary hover:border-2';
             tagList.appendChild(btn);
           });
         }
@@ -1011,8 +1011,6 @@
         function applyData(data) {
           rawData = data;
           renderTags(collectTags(data));
-          selectedTag = '';
-          searchTerm = '';
           applyFilter();
         }
       async function fetchLatest() {

--- a/main.html
+++ b/main.html
@@ -594,13 +594,13 @@
         const searchBtn = document.createElement('button');
         searchBtn.id = 'searchBtn';
         searchBtn.textContent = '🔍︎';
-        searchBtn.className = 'px-3 py-1 rounded-full text-sm border hover:bg-primary/10';
+        searchBtn.className = 'px-3 py-1 rounded-full text-sm border hover:border-primary hover:border-2';
         tagList.appendChild(searchBtn);
         tags.forEach((t) => {
           const btn = document.createElement('button');
           btn.dataset.tag = t;
           btn.textContent = t;
-          btn.className = 'px-3 py-1 rounded-full text-sm border hover:bg-primary/10';
+          btn.className = 'px-3 py-1 rounded-full text-sm border hover:border-primary hover:border-2';
           tagList.appendChild(btn);
         });
       }
@@ -661,8 +661,6 @@
       function applyData(data) {
         rawData = data;
         renderTags(collectTags(data));
-        selectedTag = '';
-        searchTerm = '';
         applyFilter();
       }
       async function fetchLatest() {


### PR DESCRIPTION
## Summary
- preserve selected tag on mobile when new data loads
- replace hover background with stronger border style for tags

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6858f0562d48832eb249e3a2f9dcb92c