### PR TITLE
Align tag list with gallery

### DIFF
--- a/ideas.html
+++ b/ideas.html
@@ -477,8 +477,8 @@
   </nav>
   <div id="content" class="ml-[72px]">
     <header class="py-2 text-center"> </header>
-    <div id="tagList" class="flex overflow-x-auto whitespace-nowrap gap-2 px-4 mb-4 no-scrollbar"></div>
-    <main class="px-4 max-w-screen-xl mx-auto">
+    <div id="tagList" class="flex overflow-x-auto whitespace-nowrap gap-2 px-4 mb-4 no-scrollbar max-w-screen-xl mx-auto"></div>
+    <main class="px-4 max-w-screen-xl mx-auto pb-8">
       <!-- Masonry 容器 -->
       <div class="masonry" id="gallery"></div> <button id="loadMore" class="mt-4 mx-auto block px-4 py-2 rounded bg-gray-200 text-gray-700 hidden">
           加载更多
@@ -844,9 +844,9 @@
         link.rel = "noopener noreferrer";
         link.addEventListener("click", (e) => e.stopPropagation());
         const bottom = document.createElement("div");
-        bottom.className = "flex justify-between items-end mt-auto";
+        bottom.className = "flex items-end mt-auto gap-2";
         const tagsEl = document.createElement("div");
-        tagsEl.className = "flex flex-wrap gap-1";
+        tagsEl.className = "flex overflow-x-auto whitespace-nowrap gap-1 no-scrollbar";
         if (Array.isArray(item.tags) && item.tags.length > 0) {
           for (const tag of item.tags) {
             const span = document.createElement("span");

--- a/main.html
+++ b/main.html
@@ -322,9 +322,9 @@
     <header class="py-2 text-center">
       <h2 class="text-1xl font-bold tracking-tight text-on-surface"></h2>
     </header>
-    <div id="tagList" class="flex overflow-x-auto whitespace-nowrap gap-2 px-4 mb-4 no-scrollbar"></div>
+    <div id="tagList" class="flex overflow-x-auto whitespace-nowrap gap-2 px-4 mb-4 no-scrollbar max-w-screen-xl mx-auto"></div>
 
-    <main class="px-4 max-w-screen-xl mx-auto">
+    <main class="px-4 max-w-screen-xl mx-auto pb-8">
       <!-- Masonry 容器 -->
       <div class="masonry" id="gallery"></div>
       <button id="loadMore" class="mt-4 mx-auto block px-4 py-2 rounded bg-gray-200 text-gray-700 hidden">加载更多</button>


### PR DESCRIPTION
## Summary
- align tagList row with gallery container
- add bottom padding to `main` content on main & ideas pages
- allow horizontal scrolling for long article tag lists with spacing before the source link

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_685945406b28832e85f0ed4f26fa1110