### PR TITLE
Integrate article viewer with /a short links

### DIFF
--- a/ideas.html
+++ b/ideas.html
@@ -702,7 +702,7 @@
         attempt();
       }
       async function fetchWithFallback(path, options = {}) {
-        const isApi = path.startsWith('/api/wx') || path.startsWith('/api/article') || path.startsWith('/api/daily');
+        const isApi = path.startsWith('/api/wx') || path.startsWith('/api/article') || path.startsWith('/api/daily') || path.startsWith('/a/');
         const domains = isApi ? apiDomains : imgDomains;
         for (const d of domains) {
           try {
@@ -824,6 +824,9 @@
         const wrapper = document.createElement("div");
         wrapper.className = "masonry-item rounded-2xl shadow overflow-hidden flex flex-col cursor-pointer";
         wrapper.dataset.url = item.url;
+        if (item.abbrlink) {
+          wrapper.dataset.abbr = item.abbrlink;
+        }
         if (item.imgSrc) {
           const img = createImage(item.imgSrc, item.title);
           wrapper.appendChild(img);
@@ -863,13 +866,14 @@
         wrapper.appendChild(text);
         wrapper.addEventListener("click", async () => {
           const url = wrapper.dataset.url;
-          if (!url) return;
+          const abbr = wrapper.dataset.abbr;
+          if (!url || !abbr) return;
           const key = "article:" + url;
           let html = localStorage.getItem(key);
           if (!html) {
             showLoading();
             try {
-              const res = await fetchWithFallback(`/api/article?url=${encodeURIComponent(url)}`, );
+              const res = await fetchWithFallback(`/a/${abbr}?view=1`, );
               html = await res.text();
               if (res.ok) {
                 localStorage.setItem(key, html);
@@ -918,9 +922,9 @@
 
         function buildItems(data) {
           const items = [];
-          for (const [title, { description, images, url, tags }] of Object.entries(data)) {
+          for (const [title, { description, images, url, tags, abbrlink }] of Object.entries(data)) {
             const imgSrc = Array.isArray(images) && images.length > 0 ? images[Math.floor(Math.random() * images.length)] : null;
-            items.push({ title, description, imgSrc, url, tags });
+            items.push({ title, description, imgSrc, url, tags, abbrlink });
           }
           return items;
         }

--- a/main.html
+++ b/main.html
@@ -452,7 +452,7 @@
         attempt();
       }
       async function fetchWithFallback(path, options = {}) {
-        const isApi = path.startsWith('/api/wx') || path.startsWith('/api/article') || path.startsWith('/api/daily');
+        const isApi = path.startsWith('/api/wx') || path.startsWith('/api/article') || path.startsWith('/api/daily') || path.startsWith('/a/');
         const domains = isApi ? apiDomains : imgDomains;
         for (const d of domains) {
           try {

--- a/server.js
+++ b/server.js
@@ -223,7 +223,7 @@ async function buildArticlePage(url, abbr, res) {
       }
     });
     const content = proxifyHtml($('#js_content').html() || '');
-    const page = `<!DOCTYPE html><html lang="zh-CN"><head><meta charset="utf-8" /><title>${title}</title></head><body><h1 class="text-2xl font-semibold mb-2">${title}</h1><p><a href="${url}" target="_blank" rel="noopener noreferrer">查看原文</a></p>${content}</body></html>`;
+    const page = `<!DOCTYPE html><html lang="zh-CN"><head><meta charset="utf-8" /><title>${title}</title></head><body><h1 class="text-2xl font-semibold mb-2">${title}</h1>${content}</body></html>`;
     res.setHeader('Content-Type', 'text/html; charset=utf-8');
     res.send(page);
   } catch (err) {

--- a/server.ts
+++ b/server.ts
@@ -292,7 +292,6 @@ async function buildArticlePage(url: string, abbr?: string): Promise<Response> {
   </head>
   <body>
     <h1 class="text-2xl font-semibold mb-2">${title}</h1>
-    <p><a href="${url}" target="_blank" rel="noopener noreferrer">查看原文</a></p>
     ${content}
   </body>
 </html>`;

--- a/server.ts
+++ b/server.ts
@@ -254,6 +254,56 @@ function proxifyHtml(html: string): string {
   return $.html();
 }
 
+// ---------- 生成离线文章页面 ----------
+async function buildArticlePage(url: string, abbr?: string): Promise<Response> {
+  try {
+    const res = await fetch(url, {
+      headers: {
+        "User-Agent": "Mozilla/5.0 (Deno)",
+        Referer: "https://mp.weixin.qq.com/",
+      },
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const html = await res.text();
+    const $ = cheerio.load(html, { decodeEntities: false });
+    let title = $("#activity-name").text().trim() ||
+      $(".rich_media_title").text().trim() ||
+      randomSentence();
+    if (abbr) {
+      const found = articles.find((a) => a.abbrlink === abbr);
+      if (found?.title) title = found.title;
+    }
+    $("#js_content img").each((_, el) => {
+      const src = $(el).attr("data-src") || $(el).attr("src");
+      if (src) {
+        const imgPath = `?url=${encodeURIComponent(src)}`;
+        const domain = imgDomains[0];
+        const full = domain ? domain.replace(/\/$/, "") + imgPath : imgPath;
+        $(el).attr("src", full);
+        $(el).removeAttr("data-src");
+      }
+    });
+    const content = proxifyHtml($("#js_content").html() || "");
+    const page = `<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <title>${title}</title>
+  </head>
+  <body>
+    <h1 class="text-2xl font-semibold mb-2">${title}</h1>
+    <p><a href="${url}" target="_blank" rel="noopener noreferrer">查看原文</a></p>
+    ${content}
+  </body>
+</html>`;
+    return new Response(page, {
+      headers: withCors({ "Content-Type": "text/html; charset=utf-8" }),
+    });
+  } catch (err) {
+    return json({ error: err.message }, 500);
+  }
+}
+
 // ---------- 反向代理图片 ----------
 async function proxyImage(imgUrl: string): Promise<Response> {
   try {
@@ -300,6 +350,9 @@ async function handler(req: Request): Promise<Response> {
     const abbr = abbrMatch[1];
     const found = articles.find((a) => a.abbrlink === abbr);
     if (found) {
+      if (searchParams.get("view") === "1") {
+        return await buildArticlePage(found.url, abbr);
+      }
       return Response.redirect(found.url, 302);
     }
     return new Response("not found", { status: 404, headers: withCors() });
@@ -345,63 +398,63 @@ async function handler(req: Request): Promise<Response> {
     }
   }
 
-  // /api/article —— 抓取单篇文章并返回 HTML
-  if (pathname === "/api/article") {
-    const abbr = searchParams.get("abbr");
-    let url = searchParams.get("url");
-    if (abbr) {
-      const found = articles.find((a) => a.abbrlink === abbr);
-      if (found) url = found.url;
-    }
-    if (!url) url = articles[0]?.url;
-    if (!url) return json({ error: "missing url" }, 400);
-    try {
-      const res = await fetch(url, {
-        headers: {
-          "User-Agent": "Mozilla/5.0 (Deno)",
-          Referer: "https://mp.weixin.qq.com/",
-        },
-      });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const html = await res.text();
-      const $ = cheerio.load(html, { decodeEntities: false });
-      let title = $("#activity-name").text().trim() ||
-        $(".rich_media_title").text().trim() ||
-        randomSentence();
-      if (abbr) {
-        const found = articles.find((a) => a.abbrlink === abbr);
-        if (found?.title) title = found.title;
-      }
-      // 将微信文章中的 data-src 替换为 src，方便直接展示图片
-      $("#js_content img").each((_, el) => {
-        const src = $(el).attr("data-src") || $(el).attr("src");
-        if (src) {
-          const imgPath = `?url=${encodeURIComponent(src)}`;
-          const domain = imgDomains[0];
-          const full = domain ? domain.replace(/\/$/, "") + imgPath : imgPath;
-          $(el).attr("src", full);
-          $(el).removeAttr("data-src");
-        }
-      });
-      const content = proxifyHtml($("#js_content").html() || "");
-      const page = `<!DOCTYPE html>
-<html lang="zh-CN">
-  <head>
-    <meta charset="utf-8" />
-    <title>${title}</title>
-  </head>
-  <body>
-    <h1 class="text-2xl font-semibold mb-2">${title}</h1>
-    ${content}
-  </body>
-</html>`;
-      return new Response(page, {
-        headers: withCors({ "Content-Type": "text/html; charset=utf-8" }),
-      });
-    } catch (err) {
-      return json({ error: err.message }, 500);
-    }
-  }
+//   // /api/article —— 抓取单篇文章并返回 HTML
+//   if (pathname === "/api/article") {
+//     const abbr = searchParams.get("abbr");
+//     let url = searchParams.get("url");
+//     if (abbr) {
+//       const found = articles.find((a) => a.abbrlink === abbr);
+//       if (found) url = found.url;
+//     }
+//     if (!url) url = articles[0]?.url;
+//     if (!url) return json({ error: "missing url" }, 400);
+//     try {
+//       const res = await fetch(url, {
+//         headers: {
+//           "User-Agent": "Mozilla/5.0 (Deno)",
+//           Referer: "https://mp.weixin.qq.com/",
+//         },
+//       });
+//       if (!res.ok) throw new Error(`HTTP ${res.status}`);
+//       const html = await res.text();
+//       const $ = cheerio.load(html, { decodeEntities: false });
+//       let title = $("#activity-name").text().trim() ||
+//         $(".rich_media_title").text().trim() ||
+//         randomSentence();
+//       if (abbr) {
+//         const found = articles.find((a) => a.abbrlink === abbr);
+//         if (found?.title) title = found.title;
+//       }
+//       // 将微信文章中的 data-src 替换为 src，方便直接展示图片
+//       $("#js_content img").each((_, el) => {
+//         const src = $(el).attr("data-src") || $(el).attr("src");
+//         if (src) {
+//           const imgPath = `?url=${encodeURIComponent(src)}`;
+//           const domain = imgDomains[0];
+//           const full = domain ? domain.replace(/\/$/, "") + imgPath : imgPath;
+//           $(el).attr("src", full);
+//           $(el).removeAttr("data-src");
+//         }
+//       });
+//       const content = proxifyHtml($("#js_content").html() || "");
+//       const page = `<!DOCTYPE html>
+// <html lang="zh-CN">
+//   <head>
+//     <meta charset="utf-8" />
+//     <title>${title}</title>
+//   </head>
+//   <body>
+//     <h1 class="text-2xl font-semibold mb-2">${title}</h1>
+//     ${content}
+//   </body>
+// </html>`;
+//       return new Response(page, {
+//         headers: withCors({ "Content-Type": "text/html; charset=utf-8" }),
+//       });
+//     } catch (err) {
+//       return json({ error: err.message }, 500);
+//     }
+//   }
 
   if (pathname === "/sw.js") {
     return new Response(swHtml, {

--- a/sw.js
+++ b/sw.js
@@ -32,8 +32,10 @@ self.addEventListener("fetch", (event) => {
     event.respondWith(cacheThenNetwork(event.request));
   } else if (url.pathname.startsWith("/img")) {
     event.respondWith(cacheThenNetwork(event.request));
-  } else if (url.pathname === "/api/article") {
+  } else if (url.pathname.startsWith("/a/") && url.searchParams.get("view") === "1") {
     event.respondWith(cacheThenNetwork(event.request));
+  // } else if (url.pathname === "/api/article") {
+  //   event.respondWith(cacheThenNetwork(event.request));
   } else if (url.pathname === "/") {
     event.respondWith(cacheThenNetwork(event.request));
   } else if (url.pathname === "/ideas") {

--- a/worker.js
+++ b/worker.js
@@ -153,6 +153,44 @@ function proxifyHtml(html) {
   return $.html();
 }
 
+async function buildArticlePage(url, abbr) {
+  try {
+    const res = await fetch(url, {
+      headers: {
+        "User-Agent": "Mozilla/5.0",
+        Referer: "https://mp.weixin.qq.com/",
+      },
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const html = await res.text();
+    const $ = cheerio.load(html, { decodeEntities: false });
+    let title = $('#activity-name').text().trim() ||
+      $('.rich_media_title').text().trim() ||
+      randomSentence();
+    if (abbr) {
+      const found = articles.find((a) => a.abbrlink === abbr);
+      if (found && found.title) title = found.title;
+    }
+    $('#js_content img').each((_, el) => {
+      const src = $(el).attr('data-src') || $(el).attr('src');
+      if (src) {
+        const imgPath = `?url=${encodeURIComponent(src)}`;
+        const domain = imgDomains[0];
+        const full = domain ? domain.replace(/\/$/, '') + imgPath : imgPath;
+        $(el).attr('src', full);
+        $(el).removeAttr('data-src');
+      }
+    });
+    const content = proxifyHtml($('#js_content').html() || "");
+    const page = `<!DOCTYPE html><html lang="zh-CN"><head><meta charset="utf-8" /><title>${title}</title></head><body><h1 class="text-2xl font-semibold mb-2">${title}</h1><p><a href="${url}" target="_blank" rel="noopener noreferrer">查看原文</a></p>${content}</body></html>`;
+    return new Response(page, {
+      headers: withCors({ "Content-Type": "text/html; charset=utf-8" }),
+    });
+  } catch (err) {
+    return json({ error: err.message }, 500);
+  }
+}
+
 async function proxyImage(imgUrl) {
   try {
     const wechatRes = await fetch(imgUrl, {
@@ -236,8 +274,12 @@ export default {
 
     const abbrMatch = pathname.match(/^\/a\/([\w-]+)$/);
     if (abbrMatch) {
-      const found = articles.find((a) => a.abbrlink === abbrMatch[1]);
+      const abbr = abbrMatch[1];
+      const found = articles.find((a) => a.abbrlink === abbr);
       if (found) {
+        if (searchParams.get("view") === "1") {
+          return await buildArticlePage(found.url, abbr);
+        }
         return Response.redirect(found.url, 302);
       }
       return new Response("not found", { status: 404, headers: withCors() });
@@ -294,48 +336,48 @@ export default {
       }
     }
 
-    if (pathname === "/api/article") {
-      const abbr = searchParams.get("abbr");
-      let url = searchParams.get("url");
-      if (abbr) {
-        const found = articles.find((a) => a.abbrlink === abbr);
-        if (found) url = found.url;
-      }
-      if (!url) url = articles[0]?.url;
-      if (!url) return json({ error: "missing url" }, 400);
-      try {
-        const res = await fetch(url, {
-          headers: {
-            "User-Agent": "Mozilla/5.0",
-            Referer: "https://mp.weixin.qq.com/",
-          },
-        });
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        const html = await res.text();
-        const $ = cheerio.load(html, { decodeEntities: false });
-        let title = $('#activity-name').text().trim() ||
-          $('.rich_media_title').text().trim() ||
-          randomSentence();
-        if (abbr) {
-          const found = articles.find((a) => a.abbrlink === abbr);
-          if (found && found.title) title = found.title;
-        }
-        $('#js_content img').each((_, el) => {
-          const src = $(el).attr('data-src') || $(el).attr('src');
-          if (src) {
-            $(el).attr('src', `/img?url=${encodeURIComponent(src)}`);
-            $(el).removeAttr('data-src');
-          }
-        });
-        const content = proxifyHtml($('#js_content').html() || "");
-        const page = `<!DOCTYPE html><html lang="zh-CN"><head><meta charset="utf-8" /><title>${title}</title></head><body><h1 class="text-2xl font-semibold mb-2">${title}</h1>${content}</body></html>`;
-        return new Response(page, {
-          headers: withCors({ "Content-Type": "text/html; charset=utf-8" }),
-        });
-      } catch (err) {
-        return json({ error: err.message }, 500);
-      }
-    }
+//     if (pathname === "/api/article") {
+//       const abbr = searchParams.get("abbr");
+//       let url = searchParams.get("url");
+//       if (abbr) {
+//         const found = articles.find((a) => a.abbrlink === abbr);
+//         if (found) url = found.url;
+//       }
+//       if (!url) url = articles[0]?.url;
+//       if (!url) return json({ error: "missing url" }, 400);
+//       try {
+//         const res = await fetch(url, {
+//           headers: {
+//             "User-Agent": "Mozilla/5.0",
+//             Referer: "https://mp.weixin.qq.com/",
+//           },
+//         });
+//         if (!res.ok) throw new Error(`HTTP ${res.status}`);
+//         const html = await res.text();
+//         const $ = cheerio.load(html, { decodeEntities: false });
+//         let title = $('#activity-name').text().trim() ||
+//           $('.rich_media_title').text().trim() ||
+//           randomSentence();
+//         if (abbr) {
+//           const found = articles.find((a) => a.abbrlink === abbr);
+//           if (found && found.title) title = found.title;
+//         }
+//         $('#js_content img').each((_, el) => {
+//           const src = $(el).attr('data-src') || $(el).attr('src');
+//           if (src) {
+//             $(el).attr('src', `/img?url=${encodeURIComponent(src)}`);
+//             $(el).removeAttr('data-src');
+//           }
+//         });
+//         const content = proxifyHtml($('#js_content').html() || "");
+//         const page = `<!DOCTYPE html><html lang="zh-CN"><head><meta charset="utf-8" /><title>${title}</title></head><body><h1 class="text-2xl font-semibold mb-2">${title}</h1>${content}</body></html>`;
+//         return new Response(page, {
+//           headers: withCors({ "Content-Type": "text/html; charset=utf-8" }),
+//         });
+//       } catch (err) {
+//         return json({ error: err.message }, 500);
+//       }
+//     }
 
     if (pathname === "/sw.js") {
         const swHtml = `
@@ -377,8 +419,10 @@ self.addEventListener("fetch", (event) => {
     event.respondWith(cacheThenNetwork(event.request));
   } else if (url.pathname.startsWith("/img")) {
     event.respondWith(cacheThenNetwork(event.request));
-  } else if (url.pathname === "/api/article") {
+  } else if (url.pathname.startsWith("/a/") && url.searchParams.get("view") === "1") {
     event.respondWith(cacheThenNetwork(event.request));
+  // } else if (url.pathname === "/api/article") {
+  //   event.respondWith(cacheThenNetwork(event.request));
   } else if (url.pathname === "/") {
     event.respondWith(cacheThenNetwork(event.request));
   } else if (url.pathname === "/ideas") {

--- a/worker.js
+++ b/worker.js
@@ -182,7 +182,7 @@ async function buildArticlePage(url, abbr) {
       }
     });
     const content = proxifyHtml($('#js_content').html() || "");
-    const page = `<!DOCTYPE html><html lang="zh-CN"><head><meta charset="utf-8" /><title>${title}</title></head><body><h1 class="text-2xl font-semibold mb-2">${title}</h1><p><a href="${url}" target="_blank" rel="noopener noreferrer">查看原文</a></p>${content}</body></html>`;
+    const page = `<!DOCTYPE html><html lang="zh-CN"><head><meta charset="utf-8" /><title>${title}</title></head><body><h1 class="text-2xl font-semibold mb-2">${title}</h1>${content}</body></html>`;
     return new Response(page, {
       headers: withCors({ "Content-Type": "text/html; charset=utf-8" }),
     });


### PR DESCRIPTION
## Summary
- add `buildArticlePage` helper to generate offline article page
- serve article HTML via `/a/{abbr}?view=1`
- comment out old `/api/article` endpoint
- update worker/Service Worker and frontend to use new URL
- extend Node version with same changes

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6859ecbfe59c832ead7711632cd54d99