### PR TITLE
Fix /api/wx missing images by setting referer

### DIFF
--- a/lib/wx.js
+++ b/lib/wx.js
@@ -5,7 +5,13 @@ export async function fetchWxTitle(url, fetchFn = fetch) {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), 15000);
   try {
-    const res = await fetchFn(url, { headers: { 'User-Agent': 'Mozilla/5.0' }, signal: controller.signal });
+    const res = await fetchFn(url, {
+      headers: {
+        'User-Agent': 'Mozilla/5.0',
+        Referer: 'https://mp.weixin.qq.com/',
+      },
+      signal: controller.signal,
+    });
     const html = await res.text();
     const $ = cheerio.load(html, { decodeEntities: false });
     const t = $('#activity-name').text().trim() || $('.rich_media_title').text().trim();
@@ -22,7 +28,13 @@ export async function scrapeWx(article, fetchFn = fetch) {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), 15000);
   try {
-    const res = await fetchFn(url, { headers: { 'User-Agent': 'Mozilla/5.0' }, signal: controller.signal });
+    const res = await fetchFn(url, {
+      headers: {
+        'User-Agent': 'Mozilla/5.0',
+        Referer: 'https://mp.weixin.qq.com/',
+      },
+      signal: controller.signal,
+    });
     const html = await res.text();
     const $ = cheerio.load(html, { decodeEntities: false });
     const name = article.title || $('#activity-name').text().trim() || $('.rich_media_title').text().trim() || randomSentence();


### PR DESCRIPTION
## Summary
- ensure WeChat requests send a Referer header when fetching title and content

## Testing
- `npm test` *(fails: Missing script)*
- `node --version`


------
https://chatgpt.com/codex/tasks/task_b_685a6ad6d714832ebd2e0fbd3df04a54