### PR TITLE
Allow multi-select tags

### DIFF
--- a/main.html
+++ b/main.html
@@ -512,7 +512,7 @@
       let allItems = [];
       let currentPage = 0;
       let perPage = savedPerPage;
-      let selectedTag = '';
+      let selectedTags = [];
       let searchTerm = '';
       const observer = new IntersectionObserver((entries, obs) => {
         entries.forEach((entry) => {
@@ -608,8 +608,11 @@
       function filterData(data) {
         const filtered = {};
         for (const [k, v] of Object.entries(data)) {
-          if (selectedTag && (!Array.isArray(v.tags) || !v.tags.includes(selectedTag))) {
-            continue;
+          if (selectedTags.length) {
+            const tags = Array.isArray(v.tags) ? v.tags : [];
+            if (!selectedTags.some((t) => tags.includes(t))) {
+              continue;
+            }
           }
           if (searchTerm && !k.includes(searchTerm)) {
             continue;
@@ -626,7 +629,7 @@
         renderPage();
         Array.from(tagList.querySelectorAll('button[data-tag]')).forEach((btn) => {
           btn.classList.remove('bg-primary', 'text-white', 'border-primary');
-          if (btn.dataset.tag === selectedTag) {
+          if (selectedTags.includes(btn.dataset.tag)) {
             btn.classList.add('bg-primary', 'text-white', 'border-primary');
           }
         });
@@ -720,7 +723,13 @@
         }
         const btn = e.target.closest('button[data-tag]');
         if (!btn) return;
-        selectedTag = btn.dataset.tag || '';
+        const tag = btn.dataset.tag;
+        if (!tag) return;
+        if (selectedTags.includes(tag)) {
+          selectedTags = selectedTags.filter((t) => t !== tag);
+        } else {
+          selectedTags.push(tag);
+        }
         applyFilter();
       });
       moreBtn.addEventListener('click', (e) => {


### PR DESCRIPTION
## Summary
- enable selecting multiple tags simultaneously
- highlight all selected tags and support toggling

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_685a8e5ad550832ea3ff309dd12caa5b