### PR TITLE
Add multi-tag filter to ideas page

### DIFF
--- a/ideas.html
+++ b/ideas.html
@@ -788,7 +788,7 @@
         let allItems = [];
         let currentPage = 0;
         let perPage = savedPerPage;
-        let selectedTag = '';
+        let selectedTags = [];
         let searchTerm = '';
         const EXTRA_TAGS = ['电影'];
       const observer = new IntersectionObserver(
@@ -980,10 +980,10 @@
           const filtered = {};
           for (const [k, v] of Object.entries(data)) {
             const tags = Array.isArray(v.tags) ? v.tags : [];
-            if ((selectedTag || searchTerm) && tags.length === 0) {
+            if ((selectedTags.length || searchTerm) && tags.length === 0) {
               continue;
             }
-            if (selectedTag && !tags.includes(selectedTag)) {
+            if (selectedTags.length && !selectedTags.some((t) => tags.includes(t))) {
               continue;
             }
             if (searchTerm && !k.includes(searchTerm)) {
@@ -996,8 +996,8 @@
 
         function extraItemVisible(tags) {
           if (searchTerm) return false;
-          if (!selectedTag) return true;
-          return tags.includes(selectedTag);
+          if (!selectedTags.length) return true;
+          return selectedTags.some((t) => tags.includes(t));
         }
 
         function applyFilter() {
@@ -1007,7 +1007,8 @@
           renderPage();
           Array.from(tagList.querySelectorAll('button[data-tag]')).forEach((btn) => {
             btn.classList.remove('bg-primary', 'text-white', 'border-primary');
-            if (btn.dataset.tag === selectedTag) {
+            const tag = btn.dataset.tag;
+            if (tag && selectedTags.includes(tag)) {
               btn.classList.add('bg-primary', 'text-white', 'border-primary');
             }
           });
@@ -1136,7 +1137,13 @@
           }
           const btn = e.target.closest('button[data-tag]');
           if (!btn) return;
-          selectedTag = btn.dataset.tag || '';
+          const tag = btn.dataset.tag;
+          if (!tag) return;
+          if (selectedTags.includes(tag)) {
+            selectedTags = selectedTags.filter((t) => t !== tag);
+          } else {
+            selectedTags.push(tag);
+          }
           applyFilter();
         });
       moreBtn.addEventListener("click", (e) => {


### PR DESCRIPTION
## Summary
- enable multi-select tags on ideas page similar to main page

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_685aa091a670832e86b7ee1845795091