### PR TITLE
Add loading splash screen

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -6,9 +6,37 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Admin</title>
   <script src="https://cdn.tailwindcss.com/3.4.16"></script>
+  <style>
+    #splashScreen {
+      position: fixed;
+      inset: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background-color: white;
+      z-index: 1000;
+      transition: opacity 0.4s;
+    }
+    #splashScreen .loader {
+      width: 3rem;
+      height: 3rem;
+      border: 4px solid rgba(0, 0, 0, 0.2);
+      border-top-color: #3b82f6;
+      border-radius: 50%;
+      animation: spin 1s linear infinite;
+    }
+    @keyframes spin {
+      to {
+        transform: rotate(360deg);
+      }
+    }
+  </style>
 </head>
 
 <body class="p-4">
+  <div id="splashScreen">
+    <div class="loader"></div>
+  </div>
   <h1 class="text-xl font-bold mb-2">设置域名（一行一个）</h1>
   <div class="mb-4"> <label class="block mb-1 font-semibold" for="apiInput">API 域名</label> <textarea id="apiInput" placeholder="https://a.com" class="border p-2 w-full h-24"></textarea> </div>
   <div class="mb-4"> <label class="block mb-1 font-semibold" for="imgInput">图片域名</label> <textarea id="imgInput" placeholder="https://img.com" class="border p-2 w-full h-24"></textarea> </div> <button id="saveBtn" class="bg-blue-500 text-white px-4 py-2 rounded">保存</button>
@@ -118,6 +146,27 @@
   }
   window.addEventListener('load', loadCache);
   sortSelect.addEventListener('change', loadCache);
+  </script>
+  <script>
+    const splashScreen = document.getElementById('splashScreen');
+    window.addEventListener('load', () => {
+      setTimeout(() => {
+        splashScreen.style.opacity = '0';
+        splashScreen.addEventListener('transitionend', () => {
+          splashScreen.remove();
+          document.body.classList.add('loaded');
+        }, { once: true });
+      }, Math.max(0, 2000 - performance.now()));
+    });
+    window.addEventListener('error', () => {
+      splashScreen.innerHTML = `
+        <div style="text-align:center;color:#000;padding:20px">
+          <h2>加载遇到问题</h2>
+          <p>请检查网络连接</p>
+          <button onclick="location.reload()">重试</button>
+        </div>
+      `;
+    });
   </script>
 </body>
 

--- a/ideas.html
+++ b/ideas.html
@@ -346,6 +346,34 @@
       display: none;
     }
 
+    /* Loading splash screen */
+    #splashScreen {
+      position: fixed;
+      inset: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background-color: rgb(var(--surface));
+      z-index: 1000;
+      transition: opacity 0.4s;
+    }
+    .dark #splashScreen {
+      background-color: rgb(var(--on-surface));
+    }
+    #splashScreen .loader {
+      width: 3rem;
+      height: 3rem;
+      border: 4px solid rgba(var(--on-surface), 0.2);
+      border-top-color: rgb(var(--primary));
+      border-radius: 50%;
+      animation: spin 1s linear infinite;
+    }
+    @keyframes spin {
+      to {
+        transform: rotate(360deg);
+      }
+    }
+
     /* Banner 卡片及遮罩效果 */
 
     .banner-card {
@@ -439,6 +467,9 @@
 </head>
 
 <body class="bg-surface text-on-surface min-h-screen font-sans">
+  <div id="splashScreen">
+    <div class="loader"></div>
+  </div>
   <nav class="fixed top-0 left-0 h-screen w-[72px] border-r shadow flex flex-col items-center py-4 z-49">
     <div class="sidebar-items flex flex-col items-center gap-y-6 h-full w-full"> <a href="/#" aria-label="主页" class="sidebar-link">
           <svg viewBox="0 0 24 24" fill="currentColor" class="w-6 h-6">
@@ -1198,6 +1229,27 @@
           navigator.serviceWorker.register("/sw.js").catch(console.error);
         });
       }
+    </script>
+    <script>
+      const splashScreen = document.getElementById('splashScreen');
+      window.addEventListener('load', () => {
+        setTimeout(() => {
+          splashScreen.style.opacity = '0';
+          splashScreen.addEventListener('transitionend', () => {
+            splashScreen.remove();
+            document.body.classList.add('loaded');
+          }, { once: true });
+        }, Math.max(0, 2000 - performance.now()));
+      });
+      window.addEventListener('error', () => {
+        splashScreen.innerHTML = `
+          <div style="text-align:center;color:#fff;padding:20px">
+            <h2>加载遇到问题</h2>
+            <p>请检查网络连接</p>
+            <button onclick="location.reload()">重试</button>
+          </div>
+        `;
+      });
     </script>
   </div>
 </body>

--- a/main.html
+++ b/main.html
@@ -265,6 +265,34 @@
     .no-scrollbar::-webkit-scrollbar {
       display: none;
     }
+
+    /* Loading splash screen */
+    #splashScreen {
+      position: fixed;
+      inset: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background-color: rgb(var(--surface));
+      z-index: 1000;
+      transition: opacity 0.4s;
+    }
+    .dark #splashScreen {
+      background-color: rgb(var(--on-surface));
+    }
+    #splashScreen .loader {
+      width: 3rem;
+      height: 3rem;
+      border: 4px solid rgba(var(--on-surface), 0.2);
+      border-top-color: rgb(var(--primary));
+      border-radius: 50%;
+      animation: spin 1s linear infinite;
+    }
+    @keyframes spin {
+      to {
+        transform: rotate(360deg);
+      }
+    }
   </style>
   <script>
     // 在tailwind配置前设置darkMode
@@ -288,6 +316,9 @@
 </head>
 
 <body class="bg-surface text-on-surface min-h-screen font-sans">
+  <div id="splashScreen">
+    <div class="loader"></div>
+  </div>
   <nav class="fixed top-0 left-0 h-screen w-[72px] border-r shadow flex flex-col items-center py-4 z-49">
     <div class="sidebar-items flex flex-col items-center gap-y-6 h-full w-full">
       <a href="#" aria-label="主页" class="sidebar-link">
@@ -789,6 +820,27 @@
           navigator.serviceWorker.register('/sw.js').catch(console.error);
         });
       }
+    </script>
+    <script>
+      const splashScreen = document.getElementById('splashScreen');
+      window.addEventListener('load', () => {
+        setTimeout(() => {
+          splashScreen.style.opacity = '0';
+          splashScreen.addEventListener('transitionend', () => {
+            splashScreen.remove();
+            document.body.classList.add('loaded');
+          }, { once: true });
+        }, Math.max(0, 2000 - performance.now()));
+      });
+      window.addEventListener('error', () => {
+        splashScreen.innerHTML = `
+          <div style="text-align:center;color:#fff;padding:20px">
+            <h2>加载遇到问题</h2>
+            <p>请检查网络连接</p>
+            <button onclick="location.reload()">重试</button>
+          </div>
+        `;
+      });
     </script>
   </div>
 </body>


### PR DESCRIPTION
## Summary
- add splash screen loader styles
- include loader markup at top of pages
- fade out loader when window loads, show error message if load fails

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_685b452be778832eb092d377f0d6c5bb