### PR TITLE
Adjust splash behavior

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -13,7 +13,7 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      background-color: #fff;
+      background-color: #0F172A;
       z-index: 1000;
       transition: opacity 0.4s;
     }
@@ -149,19 +149,31 @@
   sortSelect.addEventListener('change', loadCache);
   </script>
   <script>
-    const splashScreen = document.getElementById('splashScreen');
-    window.addEventListener('load', () => {
+    const splashScreen = document.getElementById("splashScreen");
+    const startTime = performance.now();
+    function hideSplash(immediate=false) {
+      const delay = immediate ? 0 : Math.max(0, 2000 - (performance.now() - startTime));
       setTimeout(() => {
-        splashScreen.style.opacity = '0';
-        splashScreen.addEventListener('transitionend', () => {
+        splashScreen.style.opacity = "0";
+        splashScreen.addEventListener("transitionend", () => {
           splashScreen.remove();
-          document.body.classList.add('loaded');
+          document.body.classList.add("loaded");
         }, { once: true });
-      }, Math.max(0, 2000 - performance.now()));
-    });
-    window.addEventListener('error', () => {
+      }, delay);
+    }
+    async function hasWxCache() {
+      if (!("caches" in window)) return false;
+      try {
+        return !!(await caches.match("/api/wx"));
+      } catch {
+        return false;
+      }
+    }
+    hasWxCache().then(found => { if (found) hideSplash(true); });
+    window.addEventListener("load", () => hideSplash());
+    window.addEventListener("error", () => {
       splashScreen.innerHTML = `
-        <div style="text-align:center;color:#000;padding:20px">
+        <div style="text-align:center;color:#fff;padding:20px">
           <h2>加载遇到问题</h2>
           <p>请检查网络连接</p>
           <button onclick="location.reload()">重试</button>

--- a/ideas.html
+++ b/ideas.html
@@ -13,7 +13,7 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      background-color: #fff;
+      background-color: #0F172A;
       z-index: 1000;
       transition: opacity 0.4s;
     }
@@ -1102,7 +1102,17 @@
         if (!res.ok) throw new Error("Network response was not ok");
         return await res.json();
       }
+      async function hasWxCache() {
+        if (!("caches" in window)) return false;
+        try {
+          return !!(await caches.match("/api/wx"));
+        } catch {
+          return false;
+        }
+      }
+
       async function initGallery() {
+        if (await hasWxCache()) hideSplash(true);
         const cachedStr = localStorage.getItem("wxData");
         let cached;
         if (cachedStr) {
@@ -1234,8 +1244,8 @@
     <script>
       const splashScreen = document.getElementById('splashScreen');
       const startTime = performance.now();
-      function hideSplash() {
-        const delay = Math.max(0, 2000 - (performance.now() - startTime));
+      function hideSplash(immediate=false) {
+        const delay = immediate ? 0 : Math.max(0, 2000 - (performance.now() - startTime));
         setTimeout(() => {
           splashScreen.style.opacity = '0';
           splashScreen.addEventListener('transitionend', () => {

--- a/main.html
+++ b/main.html
@@ -13,7 +13,7 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      background-color: #fff;
+      background-color: #0F172A;
       z-index: 1000;
       transition: opacity 0.4s;
     }
@@ -712,7 +712,16 @@
         }
         return Object.assign({}, dataWx, dataBil);
       }
+      async function hasWxCache() {
+        if (!("caches" in window)) return false;
+        try {
+          return !!(await caches.match("/api/wx"));
+        } catch {
+          return false;
+        }
+      }
       async function initGallery() {
+        if (await hasWxCache()) hideSplash(true);
         const cachedStr = localStorage.getItem('wxData');
         let cached;
         if (cachedStr) {
@@ -825,8 +834,8 @@
     <script>
       const splashScreen = document.getElementById('splashScreen');
       const startTime = performance.now();
-      function hideSplash() {
-        const delay = Math.max(0, 2000 - (performance.now() - startTime));
+      function hideSplash(immediate=false) {
+        const delay = immediate ? 0 : Math.max(0, 2000 - (performance.now() - startTime));
         setTimeout(() => {
           splashScreen.style.opacity = '0';
           splashScreen.addEventListener('transitionend', () => {


### PR DESCRIPTION
## Summary
- change splash screen background to dark color
- hide splash immediately if `/api/wx` cache exists
- centralize splash logic in admin and ideas pages

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_685b528fc2ac832e85a934b4d4ecb639