### PR TITLE
Improve splash screen style

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -13,7 +13,9 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      background-color: #0F172A;
+      background-color: rgba(15, 23, 42, 0.6);
+      backdrop-filter: blur(8px);
+      -webkit-backdrop-filter: blur(8px);
       z-index: 1000;
       transition: opacity 0.4s;
     }

--- a/ideas.html
+++ b/ideas.html
@@ -13,7 +13,9 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      background-color: #0F172A;
+      background-color: rgba(15, 23, 42, 0.6);
+      backdrop-filter: blur(8px);
+      -webkit-backdrop-filter: blur(8px);
       z-index: 1000;
       transition: opacity 0.4s;
     }

--- a/main.html
+++ b/main.html
@@ -13,7 +13,9 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      background-color: #0F172A;
+      background-color: rgba(15, 23, 42, 0.6);
+      backdrop-filter: blur(8px);
+      -webkit-backdrop-filter: blur(8px);
       z-index: 1000;
       transition: opacity 0.4s;
     }


### PR DESCRIPTION
## Summary
- update splash screen styling in main, ideas and admin pages to use a semi-transparent backdrop with gaussian blur

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_685b640efa8c832e97e6607bddec6965