### PR TITLE
Fix Node server static path

### DIFF
--- a/build.js
+++ b/build.js
@@ -28,7 +28,7 @@ await buildHtml('main.html');
 await buildHtml('ideas.html');
 await buildHtml('admin.html');
 
-const swRaw = await fs.readFile(path.join(__dirname, 'sw.js'), 'utf8');
+const swRaw = await fs.readFile(path.join(__dirname, 'static', 'sw.js'), 'utf8');
 const swOut = `const IMG_CACHE = ${JSON.stringify(cacheImgDomain)};\n${swRaw}`;
 await fs.writeFile(path.join(outDir, 'sw.js'), swOut);
 await fs.copyFile(path.join(__dirname, 'static', 'common.css'), path.join(outDir, 'common.css'));

--- a/node.js
+++ b/node.js
@@ -37,7 +37,7 @@ function injectConfig(html) {
 const indexHtml = injectConfig(await fs.readFile(path.join(__dirname, 'main.html'), 'utf8'));
 const ideasHtml = injectConfig(await fs.readFile(path.join(__dirname, 'ideas.html'), 'utf8'));
 const adminHtml = injectConfig(await fs.readFile(path.join(__dirname, 'admin.html'), 'utf8'));
-const swRaw = await fs.readFile(path.join(__dirname, 'sw.js'), 'utf8');
+const swRaw = await fs.readFile(path.join(__dirname, 'static', 'sw.js'), 'utf8');
 const swHtml = `const IMG_CACHE = ${JSON.stringify(cacheImgDomain)};\n${swRaw}`;
 
 const fallbackSentences = [


### PR DESCRIPTION
## Summary
- fix path for service worker script in build and runtime

## Testing
- `npm run build`
- `node node.js` *(fails without packages)*
- `npm install`
- `node node.js`

------
https://chatgpt.com/codex/tasks/task_b_685cbc3bad5c832e9b5b77ceccacc3e6