### PR TITLE
Add cached poster wall

### DIFF
--- a/add.html
+++ b/add.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>海报墙</title>
+  <link rel="stylesheet" href="common.css">
+  <link rel="stylesheet" href="ideas.css">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script defer src="common.js"></script>
+  <script>
+    tailwind.config = {
+      darkMode: 'class',
+      theme: {
+        extend: {
+          colors: {
+            primary: 'rgb(var(--primary))',
+            secondary: 'rgb(var(--secondary))',
+            accent: 'rgb(var(--accent))',
+            surface: 'rgb(var(--surface))',
+            'on-surface': 'rgb(var(--on-surface))',
+            card: 'rgb(var(--card))',
+            border: 'rgb(var(--border))'
+          }
+        }
+      }
+    }
+  </script>
+</head>
+<body class="bg-surface text-on-surface min-h-screen font-sans">
+  <div id="splashScreen">
+    <div class="loader"></div>
+  </div>
+  <div data-include="sidebar.html"></div>
+  <div id="content" class="ml-[72px]">
+    <header class="py-2 text-center"></header>
+    <main class="px-4 max-w-screen-xl mx-auto pb-8">
+      <div class="masonry" id="gallery"></div>
+    </main>
+    <div data-include="settings.html"></div>
+  </div>
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+  window.commonReady?.then(() => {
+    const gallery = document.getElementById('gallery');
+    const imgStored = localStorage.getItem('imgDomains') || '';
+    let imgDomains = imgStored ? imgStored.split(/\r?\n|,/).map(s => s.trim()).filter(Boolean) : [];
+    if (imgDomains.length === 0 && Array.isArray(window.IMG_DOMAINS)) {
+      imgDomains = window.IMG_DOMAINS;
+    }
+    function buildUrl(path, domain) {
+      return domain ? domain.replace(/\/$/, '') + path : path;
+    }
+    function loadImgWithFallback(img) {
+      const path = img.dataset.path;
+      if (!path) return;
+      let index = 0;
+      function attempt() {
+        img.src = buildUrl(path, imgDomains[index] || '');
+      }
+      img.onerror = () => {
+        index++;
+        if (index < imgDomains.length) attempt();
+      };
+      attempt();
+    }
+    function getCachedImageUrls() {
+      try {
+        const data = JSON.parse(localStorage.getItem('wxData') || 'null');
+        if (!data) return [];
+        const urls = [];
+        Object.values(data).forEach(item => {
+          if (Array.isArray(item.images)) urls.push(...item.images);
+        });
+        return urls;
+      } catch {
+        return [];
+      }
+    }
+    function createPoster(src) {
+      const wrapper = document.createElement('div');
+      wrapper.className = 'masonry-item rounded overflow-hidden';
+      const img = document.createElement('img');
+      img.className = 'w-full object-cover aspect-[2/3]';
+      img.dataset.path = `?url=${encodeURIComponent(src)}`;
+      img.alt = '';
+      img.loading = 'lazy';
+      loadImgWithFallback(img);
+      wrapper.appendChild(img);
+      return wrapper;
+    }
+    function render() {
+      const urls = getCachedImageUrls();
+      if (urls.length === 0) {
+        gallery.innerHTML = '<p class="text-center text-gray-500">暂无缓存图片</p>';
+        hideSplash();
+        return;
+      }
+      const shuffled = urls.sort(() => Math.random() - 0.5);
+      shuffled.forEach(u => {
+        gallery.appendChild(createPoster(u));
+      });
+      hideSplash();
+    }
+    render();
+  });
+});
+</script>
+<script>
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('/sw.js').catch(console.error);
+  });
+}
+</script>
+</body>
+</html>

--- a/build.js
+++ b/build.js
@@ -27,6 +27,7 @@ async function buildHtml(name) {
 await buildHtml('main.html');
 await buildHtml('ideas.html');
 await buildHtml('admin.html');
+await buildHtml('add.html');
 
 const swRaw = await fs.readFile(path.join(__dirname, 'static', 'sw.js'), 'utf8');
 const swOut = `const IMG_CACHE = ${JSON.stringify(cacheImgDomain)};\n${swRaw}`;

--- a/node.js
+++ b/node.js
@@ -37,6 +37,7 @@ function injectConfig(html) {
 const indexHtml = injectConfig(await fs.readFile(path.join(__dirname, 'main.html'), 'utf8'));
 const ideasHtml = injectConfig(await fs.readFile(path.join(__dirname, 'ideas.html'), 'utf8'));
 const adminHtml = injectConfig(await fs.readFile(path.join(__dirname, 'admin.html'), 'utf8'));
+const addHtml = injectConfig(await fs.readFile(path.join(__dirname, 'add.html'), 'utf8'));
 const swRaw = await fs.readFile(path.join(__dirname, 'static', 'sw.js'), 'utf8');
 const swHtml = `const IMG_CACHE = ${JSON.stringify(cacheImgDomain)};\n${swRaw}`;
 
@@ -469,6 +470,10 @@ app.get('/@admin', (req, res) => {
 
 app.get('/ideas', (req, res) => {
   res.type('html').send(ideasHtml);
+});
+
+app.get('/add', (req, res) => {
+  res.type('html').send(addHtml);
 });
 
 app.get('*', (req, res) => {

--- a/server.ts
+++ b/server.ts
@@ -49,6 +49,9 @@ const swHtml = `const IMG_CACHE = ${JSON.stringify(cacheImgDomain)};\n${swRaw}`;
 const adminHtml = injectConfig(
   await Deno.readTextFile(join(__dirname, "admin.html")),
 );
+const addHtml = injectConfig(
+  await Deno.readTextFile(join(__dirname, "add.html")),
+);
 const fallbackSentences = [
   "小荷才露尖尖角",
   "早有蜻蜓立上头",
@@ -561,6 +564,13 @@ async function handler(req: Request): Promise<Response> {
   // /ideas —— 灵感瀑布流页面
   if (pathname === "/ideas") {
     return new Response(ideasHtml, {
+      headers: withCors({ "Content-Type": "text/html; charset=utf-8" }),
+    });
+  }
+
+  // /add —— 海报墙页面
+  if (pathname === "/add") {
+    return new Response(addHtml, {
       headers: withCors({ "Content-Type": "text/html; charset=utf-8" }),
     });
   }

--- a/static/sw.js
+++ b/static/sw.js
@@ -42,6 +42,8 @@ self.addEventListener("fetch", (event) => {
     event.respondWith(cacheThenNetwork(event.request));
   } else if (url.pathname === "/ideas") {
     event.respondWith(cacheThenNetwork(event.request));
+  } else if (url.pathname === "/add") {
+    event.respondWith(cacheThenNetwork(event.request));
   }
 });
 

--- a/worker.js
+++ b/worker.js
@@ -3,6 +3,7 @@ import * as cheerio from "cheerio";
 import mainHtml from "./main.html";
 import ideasHtml from "./ideas.html";
 import adminHtml from "./admin.html";
+import addHtml from "./add.html";
 import commonCss from "./static/common.css";
 import ideasCss from "./static/ideas.css";
 //import { commonJs } from "./static/common.js?raw";
@@ -355,6 +356,7 @@ export default {
     const indexHtml = injectConfig(mainHtml, apiDomains, imgDomains);
     const ideasPage = injectConfig(ideasHtml, apiDomains, imgDomains);
     const adminPage = injectConfig(adminHtml, apiDomains, imgDomains);
+    const addPage = injectConfig(addHtml, apiDomains, imgDomains);
 
     const articles = await getArticles(env);
 
@@ -540,6 +542,8 @@ self.addEventListener("fetch", (event) => {
     event.respondWith(cacheThenNetwork(event.request));
   } else if (url.pathname === "/ideas") {
     event.respondWith(cacheThenNetwork(event.request));
+  } else if (url.pathname === "/add") {
+    event.respondWith(cacheThenNetwork(event.request));
   }
 });
 
@@ -675,6 +679,12 @@ async function cacheThenNetwork(request) {
 
     if (pathname === "/ideas") {
       return new Response(ideasPage, {
+        headers: withCors({ "Content-Type": "text/html; charset=utf-8" }),
+      });
+    }
+
+    if (pathname === "/add") {
+      return new Response(addPage, {
         headers: withCors({ "Content-Type": "text/html; charset=utf-8" }),
       });
     }


### PR DESCRIPTION
## Summary
- add new **/add** page displaying cached images as a poster wall
- include the page in Node/Deno/Worker servers
- make service worker handle `/add`
- build script outputs `add.html`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_685cc3a5e240832e81f20b7f7eed334e