### PR TITLE
Add poster wall from cache

### DIFF
--- a/add.html
+++ b/add.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>海报墙</title>
+  <link rel="stylesheet" href="common.css">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script defer src="common.js"></script>
+  <style>
+    #mainPoster {
+      width: 100%;
+      max-height: calc(100vh - 160px);
+      object-fit: contain;
+    }
+    #thumbList {
+      display: flex;
+      overflow-x: auto;
+      gap: 0.5rem;
+      padding: 0.5rem 0.75rem;
+      position: fixed;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      background-color: rgba(255, 255, 255, 0.8);
+      backdrop-filter: blur(4px);
+    }
+    .dark #thumbList {
+      background-color: rgba(30, 41, 59, 0.8);
+    }
+    #thumbList img {
+      width: 72px;
+      height: 108px;
+      flex-shrink: 0;
+      object-fit: cover;
+      border-radius: 0.375rem;
+      cursor: pointer;
+      opacity: 0.7;
+    }
+    #thumbList img.selected {
+      outline: 2px solid rgb(var(--accent));
+      opacity: 1;
+    }
+  </style>
+</head>
+<body class="bg-surface text-on-surface min-h-screen font-sans flex flex-col items-center justify-center pb-32">
+  <div id="splashScreen"><div class="loader"></div></div>
+  <div data-include="sidebar.html"></div>
+  <div id="content" class="ml-[72px] w-full flex flex-col items-center">
+    <h1 class="text-xl font-bold mb-4">海报墙</h1>
+    <img id="mainPoster" class="rounded max-w-full" alt="海报">
+  </div>
+  <div id="thumbList" class="no-scrollbar ml-[72px]"></div>
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+  window.commonReady?.then(async () => {
+    const mainImg = document.getElementById('mainPoster');
+    const list = document.getElementById('thumbList');
+    const navEl = document.querySelector('nav');
+    const contentEl = document.getElementById('content');
+    const isMobile = /Mobi|Android|iPhone|iPad|iPod|Windows Phone/i.test(navigator.userAgent);
+    if (isMobile) {
+      document.body.classList.add('mobile');
+      navEl.classList.add('mobile');
+      contentEl.classList.remove('ml-[72px]');
+      contentEl.classList.add('mb-[72px]');
+      list.classList.remove('ml-[72px]');
+    }
+    const CACHE_NAME = 'wx-cache-v2';
+    if (!('caches' in window)) { mainImg.alt = '此浏览器不支持缓存'; window.hideSplash(); return; }
+    try {
+      const cache = await caches.open(CACHE_NAME);
+      const keys = await cache.keys();
+      const imgs = [];
+      for (const req of keys) {
+        const res = await cache.match(req);
+        if (!res) continue;
+        const type = res.headers.get('Content-Type') || '';
+        if (!type.startsWith('image')) continue;
+        imgs.push(req.url);
+      }
+      if (imgs.length === 0) {
+        mainImg.alt = '没有缓存图片';
+      } else {
+        mainImg.src = imgs[0];
+        for (const url of imgs) {
+          const thumb = document.createElement('img');
+          thumb.src = url;
+          thumb.loading = 'lazy';
+          thumb.addEventListener('click', () => {
+            document.querySelector('#thumbList img.selected')?.classList.remove('selected');
+            mainImg.src = url;
+            thumb.classList.add('selected');
+          });
+          list.appendChild(thumb);
+        }
+        list.firstChild.classList.add('selected');
+      }
+    } catch (e) {
+      mainImg.alt = '读取缓存失败';
+      console.error(e);
+    } finally {
+      window.hideSplash();
+    }
+  });
+});
+</script>
+</body>
+</html>

--- a/build.js
+++ b/build.js
@@ -27,6 +27,7 @@ async function buildHtml(name) {
 await buildHtml('main.html');
 await buildHtml('ideas.html');
 await buildHtml('admin.html');
+await buildHtml('add.html');
 
 const swRaw = await fs.readFile(path.join(__dirname, 'static', 'sw.js'), 'utf8');
 const swOut = `const IMG_CACHE = ${JSON.stringify(cacheImgDomain)};\n${swRaw}`;

--- a/node.js
+++ b/node.js
@@ -37,6 +37,7 @@ function injectConfig(html) {
 const indexHtml = injectConfig(await fs.readFile(path.join(__dirname, 'main.html'), 'utf8'));
 const ideasHtml = injectConfig(await fs.readFile(path.join(__dirname, 'ideas.html'), 'utf8'));
 const adminHtml = injectConfig(await fs.readFile(path.join(__dirname, 'admin.html'), 'utf8'));
+const addHtml = injectConfig(await fs.readFile(path.join(__dirname, 'add.html'), 'utf8'));
 const swRaw = await fs.readFile(path.join(__dirname, 'static', 'sw.js'), 'utf8');
 const swHtml = `const IMG_CACHE = ${JSON.stringify(cacheImgDomain)};\n${swRaw}`;
 
@@ -465,6 +466,10 @@ app.get('/img', async (req, res) => {
 
 app.get('/@admin', (req, res) => {
   res.type('html').send(adminHtml);
+});
+
+app.get('/add', (req, res) => {
+  res.type('html').send(addHtml);
 });
 
 app.get('/ideas', (req, res) => {

--- a/server.ts
+++ b/server.ts
@@ -49,6 +49,9 @@ const swHtml = `const IMG_CACHE = ${JSON.stringify(cacheImgDomain)};\n${swRaw}`;
 const adminHtml = injectConfig(
   await Deno.readTextFile(join(__dirname, "admin.html")),
 );
+const addHtml = injectConfig(
+  await Deno.readTextFile(join(__dirname, "add.html")),
+);
 const fallbackSentences = [
   "小荷才露尖尖角",
   "早有蜻蜓立上头",
@@ -561,6 +564,13 @@ async function handler(req: Request): Promise<Response> {
   // /ideas —— 灵感瀑布流页面
   if (pathname === "/ideas") {
     return new Response(ideasHtml, {
+      headers: withCors({ "Content-Type": "text/html; charset=utf-8" }),
+    });
+  }
+
+  // /add —— 海报墙
+  if (pathname === "/add") {
+    return new Response(addHtml, {
       headers: withCors({ "Content-Type": "text/html; charset=utf-8" }),
     });
   }

--- a/worker.js
+++ b/worker.js
@@ -3,6 +3,7 @@ import * as cheerio from "cheerio";
 import mainHtml from "./main.html";
 import ideasHtml from "./ideas.html";
 import adminHtml from "./admin.html";
+import addHtml from "./add.html";
 import commonCss from "./static/common.css";
 import ideasCss from "./static/ideas.css";
 //import { commonJs } from "./static/common.js?raw";
@@ -355,6 +356,7 @@ export default {
     const indexHtml = injectConfig(mainHtml, apiDomains, imgDomains);
     const ideasPage = injectConfig(ideasHtml, apiDomains, imgDomains);
     const adminPage = injectConfig(adminHtml, apiDomains, imgDomains);
+    const addPage = injectConfig(addHtml, apiDomains, imgDomains);
 
     const articles = await getArticles(env);
 
@@ -669,6 +671,12 @@ async function cacheThenNetwork(request) {
 
     if (pathname === "/@admin") {
       return new Response(adminPage, {
+        headers: withCors({ "Content-Type": "text/html; charset=utf-8" }),
+      });
+    }
+
+    if (pathname === "/add") {
+      return new Response(addPage, {
         headers: withCors({ "Content-Type": "text/html; charset=utf-8" }),
       });
     }


### PR DESCRIPTION
## Summary
- add poster-wall page at `/add`
- serve new page in Node/Deno/Worker servers
- include new page in build process
- show one cached image at a time with scrollable thumbnails

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_685cc3a5e240832e81f20b7f7eed334e