### PR TITLE
Fix sidebar click-through on mobile

### DIFF
--- a/static/common.css
+++ b/static/common.css
@@ -115,6 +115,11 @@
       border-top: 1px solid #e5e7eb;
     }
 
+    /* 禁用加载时的侧边栏点击穿透 */
+    body:not(.loaded) nav {
+      pointer-events: none;
+    }
+
     nav.mobile .sidebar-link {
       flex: 1;
       margin-top: 5px;

--- a/static/sidebar.html
+++ b/static/sidebar.html
@@ -1,4 +1,4 @@
-  <nav class="fixed top-0 left-0 h-screen w-[72px] border-r shadow flex flex-col items-center py-4 z-49">
+  <nav class="fixed top-0 left-0 h-screen w-[72px] border-r shadow flex flex-col items-center py-4 z-50">
     <div class="sidebar-items flex flex-col items-center gap-y-6 h-full w-full">
       <a href="/" aria-label="主页" class="sidebar-link">
         <svg viewBox="0 0 24 24" fill="currentColor" class="w-6 h-6">


### PR DESCRIPTION
## Summary
- tweak CSS to disable sidebar interaction until the splash is hidden
- increase sidebar z-index to ensure it stays on top

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_685ccd378340832ea4bc8e34d853f62d