### PR TITLE
Add GitHub gist integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 | `WX_URL` | `必填` | 获取的微信公众号文章列表，如果不填会从本地 `article.txt` 读取 |
 | `API_DOMAINS` | `可选` | 提供 `/api/wx`、`/api/article` 和 `/api/daily` 的备用域名，多个域名用逗号或空格分隔 |
 | `IMG_DOMAINS` | `可选` | 图片代理 `/img` 的备用域名，多个域名用逗号或空格分隔 |
+| `GITHUB_CLIENT_ID` | `可选` | 用于 GitHub OAuth 登录创建 Gist 的 Client ID |
+| `GITHUB_CLIENT_SECRET` | `可选` | GitHub OAuth 的 Client Secret |
 
 ## 部署到 Deno  (推荐)
 

--- a/add.html
+++ b/add.html
@@ -33,8 +33,10 @@
   </div>
   <div data-include="sidebar.html"></div>
   <div id="content" class="ml-[72px]">
-    <header class="py-2 text-center">
+    <header class="py-2 text-center space-x-2">
       <button id="addCardBtn" class="px-4 py-2 bg-primary text-white rounded hidden">新增卡片</button>
+      <button id="githubLogin" class="px-4 py-2 bg-primary text-white rounded hidden">GitHub 登录</button>
+      <button id="createGist" class="px-4 py-2 bg-primary text-white rounded hidden">创建 Gist</button>
     </header>
     <main class="px-4 max-w-screen-xl mx-auto pb-8">
       <div class="masonry" id="gallery"></div>
@@ -200,7 +202,49 @@
         }
         location.reload();
       });
-      
+
+      const loginBtn = document.getElementById('githubLogin');
+      const createGistBtn = document.getElementById('createGist');
+      async function loadGists() {
+        try {
+          const res = await fetch('/api/gists');
+          if (res.status === 401) {
+            loginBtn.classList.remove('hidden');
+            return;
+          }
+          const data = await res.json();
+          createGistBtn.classList.remove('hidden');
+          loginBtn.classList.add('hidden');
+          data.forEach(g => {
+            cards.push({
+              title: g.description || 'Gist',
+              description: '',
+              url: g.html_url,
+              tags: ['gist']
+            });
+          });
+          render();
+        } catch (err) {
+          console.error(err);
+        }
+      }
+      loginBtn.addEventListener('click', () => {
+        location.href = '/github/login';
+      });
+      createGistBtn.addEventListener('click', async () => {
+        const description = prompt('描述') || '';
+        const content = prompt('内容');
+        if (!content) return;
+        await fetch('/api/gists', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ description, content })
+        });
+        loadGists();
+      });
+
+      await loadGists();
+
     hideSplash(true);
     });
   });

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "type": "module",
   "dependencies": {
     "cheerio": "^1.0.0-rc.12",
-    "express": "^4.19.2"
+    "express": "^4.19.2",
+    "cookie-parser": "^1.4.6",
+    "node-fetch": "^3.3.2"
   },
   "scripts": {
     "build": "node build.js",


### PR DESCRIPTION
## Summary
- allow logging in via GitHub OAuth and creating gists
- show login and gist controls on the add page
- support gist routes in Node and Deno servers
- document new environment variables
- update dependencies for server

## Testing
- `npm install`
- `npm run build`
- `npm start` *(fails: manual interrupt after server start)*


------
https://chatgpt.com/codex/tasks/task_b_685d5f7cb908832e946b4e1ee9ce3381