### PR TITLE
Move Gist loader button into tag list

### DIFF
--- a/add.html
+++ b/add.html
@@ -37,7 +37,7 @@
       <button id="addCardBtn" class="px-4 py-2 bg-primary text-white rounded hidden">新增卡片</button>
     </header>
     <div id="tagList" class="flex overflow-x-auto whitespace-nowrap gap-2 px-4 mb-4 no-scrollbar max-w-screen-xl mx-auto">
-      <button id="loadGistsBtn" class="px-3 py-1 rounded-full text-sm border-2 border-transparent hover:border-primary bg-card hidden">加载 Gist</button>
+      <button id="loadGistsBtn" class="px-3 py-1 rounded-full text-sm border-2 border-transparent hover:border-primary bg-card hidden"> ↻ </button>
     </div>
     <main class="px-4 max-w-screen-xl mx-auto pb-8">
       <div class="masonry" id="gallery"></div>

--- a/add.html
+++ b/add.html
@@ -35,9 +35,10 @@
   <div id="content" class="ml-[72px]">
     <header class="py-2 text-center">
       <button id="addCardBtn" class="px-4 py-2 bg-primary text-white rounded hidden">新增卡片</button>
-      <button id="loadGistsBtn" class="px-4 py-2 bg-secondary text-white rounded hidden">加载 Gist</button>
     </header>
-    <div id="tagList" class="flex overflow-x-auto whitespace-nowrap gap-2 px-4 mb-4 no-scrollbar max-w-screen-xl mx-auto"></div>
+    <div id="tagList" class="flex overflow-x-auto whitespace-nowrap gap-2 px-4 mb-4 no-scrollbar max-w-screen-xl mx-auto">
+      <button id="loadGistsBtn" class="px-3 py-1 rounded-full text-sm border-2 border-transparent hover:border-primary bg-card hidden">加载 Gist</button>
+    </div>
     <main class="px-4 max-w-screen-xl mx-auto pb-8">
       <div class="masonry" id="gallery"></div>
     </main>
@@ -226,6 +227,7 @@
 
       function renderTags(tags) {
         tagList.innerHTML = '';
+        tagList.appendChild(loadGistsBtn);
         tags.forEach(t => {
           const btn = document.createElement('button');
           btn.dataset.tag = t;


### PR DESCRIPTION
## Summary
- relocate **加载 Gist** button inside the tag list
- give the Gist loader button the same style as tag buttons
- ensure tag rendering keeps the loader button

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_685e008a3b9c832e84991ae4666d6f85