### PR TITLE
Add front-end gist create and edit

### DIFF
--- a/add.html
+++ b/add.html
@@ -39,6 +39,7 @@
     </header>
     <div id="tagList" class="flex overflow-x-auto whitespace-nowrap gap-2 px-4 mb-4 no-scrollbar max-w-screen-xl mx-auto">
       <button id="loadGistsBtn" class="px-3 py-1 rounded-full text-sm border-2 border-transparent hover:border-primary bg-card hidden"> ↻ </button>
+      <button id="newGistBtn" class="px-3 py-1 rounded-full text-sm border-2 border-transparent hover:border-primary bg-card hidden">新增 Gist</button>
     </div>
     <main class="px-4 max-w-screen-xl mx-auto pb-8">
       <div class="masonry" id="gallery"></div>
@@ -50,12 +51,22 @@
         <div id="articleContent" class="prose max-w-none whitespace-pre-wrap"></div>
       </div>
     </div>
+    <div id="gistEditModal" class="fixed inset-0 bg-black/50 hidden items-center justify-center z-50">
+      <div class="bg-card text-on-surface rounded-xl w-11/12 max-w-3xl h-[80vh] overflow-auto relative p-4 flex flex-col gap-2">
+        <textarea id="gistEditTextarea" class="flex-1 w-full border rounded p-2 bg-surface text-on-surface"></textarea>
+        <div class="flex justify-end gap-2 mt-2">
+          <button id="cancelEditGist" class="px-3 py-1 rounded bg-gray-500 text-white">取消</button>
+          <button id="saveEditGist" class="px-3 py-1 rounded bg-primary text-white">保存</button>
+        </div>
+      </div>
+    </div>
   </div>
 <script>
   document.addEventListener('DOMContentLoaded', () => {
     window.commonReady?.then(() => {
       const gallery = document.getElementById('gallery');
       const addCardBtn = document.getElementById('addCardBtn');
+      const newGistBtn = document.getElementById('newGistBtn');
       const sidebarAddBtn = document.getElementById('addBtn');
       const settingsPanel = document.getElementById('settingsPanel');
       const moreBtn = document.getElementById('moreBtn');
@@ -70,6 +81,10 @@
       const articleModal = document.getElementById('articleModal');
       const closeArticle = document.getElementById('closeArticle');
       const articleContent = document.getElementById('articleContent');
+      const gistEditModal = document.getElementById('gistEditModal');
+      const gistEditTextarea = document.getElementById('gistEditTextarea');
+      const saveEditGist = document.getElementById('saveEditGist');
+      const cancelEditGist = document.getElementById('cancelEditGist');
       const clearCacheBtn = document.getElementById('clearCache');
       const navEl = document.querySelector('nav');
       const contentEl = document.getElementById('content');
@@ -77,7 +92,10 @@
 
       const savedToken = localStorage.getItem('githubToken') || '';
       if (githubTokenInput) githubTokenInput.value = savedToken;
-      if (savedToken) loadGistsBtn.classList.remove('hidden');
+      if (savedToken) {
+        loadGistsBtn.classList.remove('hidden');
+        newGistBtn.classList.remove('hidden');
+      }
 
       const savedCols = parseInt(localStorage.getItem('columnCount')) || 4;
       const savedPerPage = parseInt(localStorage.getItem('perPage')) || 30;
@@ -96,6 +114,7 @@
       let cards = [];
       let selectedTags = [];
       let allowMultiTags = multiTagsSaved;
+      let editIndex = null;
       load();
       updateTagsAndRender();
 
@@ -201,7 +220,18 @@
             updateTagsAndRender();
           }
         });
-        
+
+        if (item.gistId) {
+          const editBtn = document.createElement('button');
+          editBtn.className = 'text-xs text-primary flex-none';
+          editBtn.textContent = '编辑';
+          editBtn.addEventListener('click', e => {
+            e.stopPropagation();
+            handleEditGist(index);
+          });
+          bottom.appendChild(editBtn);
+        }
+
         text.appendChild(h2);
         text.appendChild(p);
         text.appendChild(bottom);
@@ -229,6 +259,7 @@
       function renderTags(tags) {
         tagList.innerHTML = '';
         tagList.appendChild(loadGistsBtn);
+        tagList.appendChild(newGistBtn);
         tags.forEach(t => {
           const btn = document.createElement('button');
           btn.dataset.tag = t;
@@ -273,6 +304,108 @@
         updateTagsAndRender();
       }
 
+      async function handleCreateGist() {
+        const filename = prompt('文件名，例如 note.md');
+        if (!filename) return;
+        const content = prompt('内容') || '';
+        const token = localStorage.getItem('githubToken');
+        if (!token) {
+          alert('请在设置中填写 GitHub Token');
+          return;
+        }
+        try {
+          const res = await fetch('https://api.github.com/gists', {
+            method: 'POST',
+            headers: {
+              Authorization: 'token ' + token,
+              'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+              description: 'flow-gist',
+              public: false,
+              files: { [filename]: { content } }
+            })
+          });
+          if (!res.ok) throw new Error('create');
+          const data = await res.json();
+          const url = data.html_url + '?file=' + encodeURIComponent(filename);
+          const fm = parseFrontMatter(content);
+          if (fm) {
+            cards.push({
+              title: fm.title || filename,
+              description: fm.description || '',
+              url,
+              tags: fm.tags.length ? fm.tags : ['gist'],
+              content: fm.content.trim(),
+              gistId: data.id,
+              filename
+            });
+          } else {
+            cards.push({
+              title: filename,
+              description: '',
+              url,
+              tags: ['gist'],
+              content: content.trim(),
+              gistId: data.id,
+              filename
+            });
+          }
+          save();
+          updateTagsAndRender();
+        } catch (e) {
+          alert('创建失败');
+          console.error(e);
+        }
+      }
+
+      function handleEditGist(index) {
+        const item = cards[index];
+        if (!item || !item.gistId) return;
+        editIndex = index;
+        gistEditTextarea.value = item.content || '';
+        gistEditModal.classList.remove('hidden');
+        gistEditModal.classList.add('flex', 'show');
+      }
+
+      async function saveEdit() {
+        const index = editIndex;
+        editIndex = null;
+        gistEditModal.classList.add('hidden');
+        gistEditModal.classList.remove('flex', 'show');
+        const item = cards[index];
+        if (!item || !item.gistId) return;
+        const content = gistEditTextarea.value;
+        const token = localStorage.getItem('githubToken');
+        if (!token) {
+          alert('请在设置中填写 GitHub Token');
+          return;
+        }
+        try {
+          const res = await fetch('https://api.github.com/gists/' + item.gistId, {
+            method: 'PATCH',
+            headers: {
+              Authorization: 'token ' + token,
+              'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({ files: { [item.filename]: { content } } })
+          });
+          if (!res.ok) throw new Error('edit');
+          item.content = content;
+          const fm = parseFrontMatter(content);
+          if (fm) {
+            item.title = fm.title || item.filename;
+            item.description = fm.description || '';
+            item.tags = fm.tags.length ? fm.tags : ['gist'];
+          }
+          save();
+          updateTagsAndRender();
+        } catch (e) {
+          alert('修改失败');
+          console.error(e);
+        }
+      }
+
       async function fetchGists() {
         const token = localStorage.getItem('githubToken');
         if (!token) {
@@ -309,7 +442,9 @@
                   description: fm.description || '',
                   url,
                   tags: fm.tags.length ? fm.tags : ['gist'],
-                  content: fm.content.trim()
+                  content: fm.content.trim(),
+                  gistId: g.id,
+                  filename: name
                 });
               } else {
                 cards.push({
@@ -317,7 +452,9 @@
                   description: '',
                   url,
                   tags: ['gist'],
-                  content: text.trim()
+                  content: text.trim(),
+                  gistId: g.id,
+                  filename: name
                 });
               }
             }
@@ -337,6 +474,7 @@
         }
       }
       addCardBtn.addEventListener('click', handleCreate);
+      newGistBtn.addEventListener('click', handleCreateGist);
       loadGistsBtn.addEventListener('click', fetchGists);
       if (sidebarAddBtn) {
         sidebarAddBtn.addEventListener('click', (e) => {
@@ -377,6 +515,19 @@
       articleModal.addEventListener('click', e => {
         if (e.target === articleModal) hideArticle();
       });
+      cancelEditGist.addEventListener('click', () => {
+        editIndex = null;
+        gistEditModal.classList.add('hidden');
+        gistEditModal.classList.remove('flex', 'show');
+      });
+      saveEditGist.addEventListener('click', saveEdit);
+      gistEditModal.addEventListener('click', e => {
+        if (e.target === gistEditModal) {
+          editIndex = null;
+          gistEditModal.classList.add('hidden');
+          gistEditModal.classList.remove('flex', 'show');
+        }
+      });
       multiTagToggle.addEventListener('change', () => {
         allowMultiTags = multiTagToggle.checked;
         localStorage.setItem('multiTags', allowMultiTags ? 'true' : 'false');
@@ -394,8 +545,13 @@
         if (githubTokenInput) {
           const t = githubTokenInput.value.trim();
           localStorage.setItem('githubToken', t);
-          if (t) loadGistsBtn.classList.remove('hidden');
-          else loadGistsBtn.classList.add('hidden');
+          if (t) {
+            loadGistsBtn.classList.remove('hidden');
+            newGistBtn.classList.remove('hidden');
+          } else {
+            loadGistsBtn.classList.add('hidden');
+            newGistBtn.classList.add('hidden');
+          }
         }
         settingsPanel.classList.add('hidden');
         settingsPanel.classList.remove('flex', 'show');

--- a/add.html
+++ b/add.html
@@ -39,7 +39,7 @@
     </header>
     <div id="tagList" class="flex overflow-x-auto whitespace-nowrap gap-2 px-4 mb-4 no-scrollbar max-w-screen-xl mx-auto">
       <button id="loadGistsBtn" class="px-3 py-1 rounded-full text-sm border-2 border-transparent hover:border-primary bg-card hidden"> ↻ </button>
-      <button id="newGistBtn" class="px-3 py-1 rounded-full text-sm border-2 border-transparent hover:border-primary bg-card hidden">新增 Gist</button>
+      <button id="newGistBtn" class="px-3 py-1 rounded-full text-sm border-2 border-transparent hover:border-primary bg-card hidden"> + </button>
     </div>
     <main class="px-4 max-w-screen-xl mx-auto pb-8">
       <div class="masonry" id="gallery"></div>


### PR DESCRIPTION
## Summary
- enable gist creation and editing in `add.html`
- expose new "新增 Gist" button in the tag bar
- allow editing gist content with a modal dialog instead of `prompt`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_685e15f18a20832eabdf8ffb1933b55e