### PR TITLE
Prevent gist modal closing on outside click

### DIFF
--- a/add.html
+++ b/add.html
@@ -556,13 +556,14 @@
       });
       saveEditGist.addEventListener('click', saveEdit);
       deleteGistBtn.addEventListener('click', deleteGist);
-      gistEditModal.addEventListener('click', e => {
-        if (e.target === gistEditModal) {
-          editIndex = null;
-          gistEditModal.classList.add('hidden');
-          gistEditModal.classList.remove('flex', 'show');
-        }
-      });
+      // 点击遮罩层时不再关闭编辑弹窗，避免误触
+      // gistEditModal.addEventListener('click', e => {
+      //   if (e.target === gistEditModal) {
+      //     editIndex = null;
+      //     gistEditModal.classList.add('hidden');
+      //     gistEditModal.classList.remove('flex', 'show');
+      //   }
+      // });
       multiTagToggle.addEventListener('change', () => {
         allowMultiTags = multiTagToggle.checked;
         localStorage.setItem('multiTags', allowMultiTags ? 'true' : 'false');

--- a/static/common.css
+++ b/static/common.css
@@ -286,7 +286,18 @@
       scrollbar-width: none;
       -ms-overflow-style: none;
     }
-    .no-scrollbar::-webkit-scrollbar {
-      display: none;
-    }
+.no-scrollbar::-webkit-scrollbar {
+  display: none;
+}
+
+/* 取消 gist 编辑框获得焦点时的边框高亮 */
+#gistEditTextarea:focus {
+  outline: none;
+  box-shadow: none;
+}
+
+/* 选中文本时不改变背景色 */
+#gistEditTextarea::selection {
+  background-color: transparent;
+}
 


### PR DESCRIPTION
## Summary
- stop closing gist edit modal when clicking overlay
- remove highlight when textarea gains focus or text is selected

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_685e7488b510832eb6c1186f29670653