### PR TITLE
Implement default GitHub token on add page

### DIFF
--- a/add.html
+++ b/add.html
@@ -91,6 +91,11 @@
       const contentEl = document.getElementById('content');
       const isMobile = /Mobi|Android|iPhone|iPad|iPod|Windows Phone/i.test(navigator.userAgent);
 
+      const DEFAULT_GITHUB_TOKEN = 'ghp_defaulttoken';
+      if (!localStorage.getItem('githubToken')) {
+        localStorage.setItem('githubToken', DEFAULT_GITHUB_TOKEN);
+      }
+
       const savedToken = localStorage.getItem('githubToken') || '';
       if (savedToken) {
         loadGistsBtn.classList.remove('hidden');


### PR DESCRIPTION
## Summary
- ensure `add.html` sets a default GitHub token if none is stored

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_685eca59b6ec832e9d1bf925e0353de9