### PR TITLE
Support offline flow inject list

### DIFF
--- a/add.html
+++ b/add.html
@@ -530,6 +530,7 @@
           const gist = data.find(g => g.description === 'flow-inject');
           if (!gist) return;
           const cache = await caches.open('wx-cache-v2');
+          const list = [];
           for (const [name, f] of Object.entries(gist.files)) {
             const r = await fetch(f.raw_url);
             if (!r.ok) continue;
@@ -544,7 +545,14 @@
                 'X-Cache-Timestamp': Date.now().toString()
               }
             }));
+            list.push('/' + name);
           }
+          await cache.put('/flowInject.json', new Response(JSON.stringify(list), {
+            headers: {
+              'Content-Type': 'application/json; charset=utf-8',
+              'X-Cache-Timestamp': Date.now().toString()
+            }
+          }));
         } catch (e) {
           console.error('preload', e);
         }

--- a/admin.html
+++ b/admin.html
@@ -67,6 +67,7 @@
       const gist = data.find(g => g.description === 'flow-inject');
       if (!gist) return;
       const cache = await caches.open('wx-cache-v2');
+      const list = [];
       for (const [name, f] of Object.entries(gist.files)) {
         const r = await fetch(f.raw_url);
         if (!r.ok) continue;
@@ -81,7 +82,14 @@
             'X-Cache-Timestamp': Date.now().toString()
           }
         }));
+        list.push('/' + name);
       }
+      await cache.put('/flowInject.json', new Response(JSON.stringify(list), {
+        headers: {
+          'Content-Type': 'application/json; charset=utf-8',
+          'X-Cache-Timestamp': Date.now().toString()
+        }
+      }));
     } catch (e) {
       console.error('preload', e);
     }

--- a/static/sw.js
+++ b/static/sw.js
@@ -46,6 +46,8 @@ self.addEventListener("fetch", (event) => {
     event.respondWith(cacheThenNetwork(event.request));
   } else if (url.pathname === "/update") {
     event.respondWith(cacheOnly(event.request));
+  } else if (url.pathname === "/flowInject.json") {
+    event.respondWith(cacheOnly(event.request));
   } else if (/^\/web\.(html|css|js)$/.test(url.pathname)) {
     event.respondWith(cacheOnly(event.request));
   }


### PR DESCRIPTION
## Summary
- write cached gist filenames to `/flowInject.json`
- serve `/flowInject.json` via service worker

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_685f60d2b02c832ebd596fcf7629d218