### PR TITLE
Support dynamic paths for flow-inject

### DIFF
--- a/add.html
+++ b/add.html
@@ -530,6 +530,7 @@
           const gist = data.find(g => g.description === 'flow-inject');
           if (!gist) return;
           const cache = await caches.open('wx-cache-v2');
+          const paths = [];
 
           for (const [name, f] of Object.entries(gist.files)) {
             const r = await fetch(f.raw_url);
@@ -539,13 +540,22 @@
             if (name.endsWith('.html')) type = 'text/html';
             else if (name.endsWith('.css')) type = 'text/css';
             else if (name.endsWith('.js')) type = 'text/javascript';
-            await cache.put('/' + name, new Response(text, {
+            const path = '/' + name;
+            await cache.put(path, new Response(text, {
               headers: {
                 'Content-Type': `${type}; charset=utf-8`,
                 'X-Cache-Timestamp': Date.now().toString()
               }
             }));
+            paths.push(path);
 
+          }
+          localStorage.setItem('injectFlow', paths.join(','));
+          if (navigator.serviceWorker && navigator.serviceWorker.controller) {
+            navigator.serviceWorker.controller.postMessage({
+              type: 'injectFlow',
+              paths
+            });
           }
         } catch (e) {
           console.error('preload', e);
@@ -644,7 +654,18 @@
 <script>
   if ('serviceWorker' in navigator) {
     window.addEventListener('load', () => {
-      navigator.serviceWorker.register('/sw.js').catch(console.error);
+      navigator.serviceWorker.register('/sw.js').then(() => {
+        const sendInject = () => {
+          const val = localStorage.getItem('injectFlow');
+          if (!val) return;
+          const paths = val.split(',').map(p => p.trim()).filter(Boolean);
+          if (navigator.serviceWorker.controller) {
+            navigator.serviceWorker.controller.postMessage({ type: 'injectFlow', paths });
+          }
+        };
+        navigator.serviceWorker.ready.then(sendInject);
+        navigator.serviceWorker.addEventListener('controllerchange', sendInject);
+      }).catch(console.error);
     });
   }
 </script>

--- a/admin.html
+++ b/admin.html
@@ -67,6 +67,7 @@
       const gist = data.find(g => g.description === 'flow-inject');
       if (!gist) return;
       const cache = await caches.open('wx-cache-v2');
+      const paths = [];
 
       for (const [name, f] of Object.entries(gist.files)) {
         const r = await fetch(f.raw_url);
@@ -76,12 +77,21 @@
         if (name.endsWith('.html')) type = 'text/html';
         else if (name.endsWith('.css')) type = 'text/css';
         else if (name.endsWith('.js')) type = 'text/javascript';
-        await cache.put('/' + name, new Response(text, {
+        const path = '/' + name;
+        await cache.put(path, new Response(text, {
           headers: {
             'Content-Type': `${type}; charset=utf-8`,
             'X-Cache-Timestamp': Date.now().toString()
           }
         }));
+        paths.push(path);
+      }
+      localStorage.setItem('injectFlow', paths.join(','));
+      if (navigator.serviceWorker && navigator.serviceWorker.controller) {
+        navigator.serviceWorker.controller.postMessage({
+          type: 'injectFlow',
+          paths
+        });
       }
     } catch (e) {
       console.error('preload', e);

--- a/ideas.html
+++ b/ideas.html
@@ -749,7 +749,18 @@ document.addEventListener('DOMContentLoaded', () => {
   <script>
       if ('serviceWorker' in navigator) {
         window.addEventListener('load', () => {
-          navigator.serviceWorker.register('/sw.js').catch(console.error);
+          navigator.serviceWorker.register('/sw.js').then(() => {
+            const sendInject = () => {
+              const val = localStorage.getItem('injectFlow');
+              if (!val) return;
+              const paths = val.split(',').map(p => p.trim()).filter(Boolean);
+              if (navigator.serviceWorker.controller) {
+                navigator.serviceWorker.controller.postMessage({ type: 'injectFlow', paths });
+              }
+            };
+            navigator.serviceWorker.ready.then(sendInject);
+            navigator.serviceWorker.addEventListener('controllerchange', sendInject);
+          }).catch(console.error);
         });
       }
   </script>

--- a/main.html
+++ b/main.html
@@ -479,7 +479,18 @@ document.addEventListener('DOMContentLoaded', () => {
   <script>
       if ('serviceWorker' in navigator) {
         window.addEventListener('load', () => {
-          navigator.serviceWorker.register('/sw.js').catch(console.error);
+          navigator.serviceWorker.register('/sw.js').then(() => {
+            const sendInject = () => {
+              const val = localStorage.getItem('injectFlow');
+              if (!val) return;
+              const paths = val.split(',').map(p => p.trim()).filter(Boolean);
+              if (navigator.serviceWorker.controller) {
+                navigator.serviceWorker.controller.postMessage({ type: 'injectFlow', paths });
+              }
+            };
+            navigator.serviceWorker.ready.then(sendInject);
+            navigator.serviceWorker.addEventListener('controllerchange', sendInject);
+          }).catch(console.error);
         });
       }
   </script>

--- a/static/sw.js
+++ b/static/sw.js
@@ -1,6 +1,12 @@
 const CACHE_NAME = "wx-cache-v2";
 const CACHE_AGE = 6 * 24 * 60 * 60 * 1000;
 const TS_HEADER = "X-Cache-Timestamp";
+let injectPaths = [];
+self.addEventListener('message', (event) => {
+  if (event.data && event.data.type === 'injectFlow') {
+    injectPaths = Array.isArray(event.data.paths) ? event.data.paths : [];
+  }
+});
 self.addEventListener("install", (event) => {
   self.skipWaiting();
   event.waitUntil(caches.open(CACHE_NAME));
@@ -47,6 +53,8 @@ self.addEventListener("fetch", (event) => {
   } else if (url.pathname === "/update") {
     event.respondWith(cacheOnly(event.request));
   } else if (url.pathname === "/flowInject.json") {
+    event.respondWith(cacheOnly(event.request));
+  } else if (injectPaths.includes(url.pathname)) {
     event.respondWith(cacheOnly(event.request));
   } else if (/^\/web\.(html|css|js)$/.test(url.pathname)) {
     event.respondWith(cacheOnly(event.request));

--- a/worker.js
+++ b/worker.js
@@ -506,6 +506,12 @@ const IMG_CACHE = ${JSON.stringify(cacheImgDomain)};
 const CACHE_NAME = "wx-cache-v2";
 const CACHE_AGE = 6 * 24 * 60 * 60 * 1000;
 const TS_HEADER = "X-Cache-Timestamp";
+let injectPaths = [];
+self.addEventListener('message', (event) => {
+  if (event.data && event.data.type === 'injectFlow') {
+    injectPaths = Array.isArray(event.data.paths) ? event.data.paths : [];
+  }
+});
 self.addEventListener("install", (event) => {
   self.skipWaiting();
   event.waitUntil(caches.open(CACHE_NAME));
@@ -549,6 +555,8 @@ self.addEventListener("fetch", (event) => {
     event.respondWith(cacheThenNetwork(event.request));
   } else if (url.pathname === "/add") {
     event.respondWith(cacheThenNetwork(event.request));
+  } else if (injectPaths.includes(url.pathname)) {
+    event.respondWith(cacheOnly(event.request));
   }
 });
 


### PR DESCRIPTION
## Summary
- cache names from the `flow-inject` gist in `preloadInject`
- notify the service worker about dynamic paths
- update service worker to cache files listed in `injectFlow`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_685f729fdbd4832e8a74cedc65aaf69b