### PR TITLE
Add Notion API integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@
 | `WX_URL` | `必填` | 获取的微信公众号文章列表，如果不填会从本地 `article.txt` 读取 |
 | `API_DOMAINS` | `可选` | 提供 `/api/wx`、`/api/article` 和 `/api/daily` 的备用域名，多个域名用逗号或空格分隔 |
 | `IMG_DOMAINS` | `可选` | 图片代理 `/img` 的备用域名，多个域名用逗号或空格分隔 |
+| `NOTION_PAGE` | `可选` | 默认加载的 Notion 表格链接 |
+
+设置 `NOTION_PAGE` 或在页面的“设置”面板中填写分享链接，即可从公开的 Notion 表格加载数据并展示到图集。
 
 ## 部署到 Deno  (推荐)
 

--- a/build.js
+++ b/build.js
@@ -10,10 +10,11 @@ await fs.mkdir(outDir, { recursive: true });
 const apiDomains = (process.env.API_DOMAINS || '').split(/[\s,]+/).filter(Boolean);
 const imgDomains = (process.env.IMG_DOMAINS || '').split(/[\s,]+/).filter(Boolean);
 const cacheImgDomain = process.env.IMG_CACHE || '';
+const notionPage = process.env.NOTION_PAGE || '';
 
 function injectConfig(html) {
-  if (!apiDomains.length && !imgDomains.length) return html;
-  const script = `<script>window.API_DOMAINS=${JSON.stringify(apiDomains)};window.IMG_DOMAINS=${JSON.stringify(imgDomains)};</script>`;
+  if (!apiDomains.length && !imgDomains.length && !notionPage) return html;
+  const script = `<script>window.API_DOMAINS=${JSON.stringify(apiDomains)};window.IMG_DOMAINS=${JSON.stringify(imgDomains)};window.NOTION_PAGE=${JSON.stringify(notionPage)};</script>`;
   return html.replace('</head>', `${script}</head>`);
 }
 

--- a/ideas.html
+++ b/ideas.html
@@ -184,6 +184,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const applySettings = document.getElementById("applySettings");
       const columnCountInput = document.getElementById("columnCountInput");
       const perPageInput = document.getElementById("perPageInput");
+      const notionPageInput = document.getElementById("notionPageInput");
       const multiTagToggle = document.getElementById("multiTagToggle");
       const articleModal = document.getElementById("articleModal");
       const closeArticle = document.getElementById("closeArticle");
@@ -192,8 +193,10 @@ document.addEventListener('DOMContentLoaded', () => {
       let dailyData = null;
       const apiStored = localStorage.getItem('apiDomains') || localStorage.getItem('apiDomain') || '';
       const imgStored = localStorage.getItem('imgDomains') || '';
+      const notionStored = localStorage.getItem('notionPage') || '';
       let apiDomains = apiStored ? apiStored.split(/\r?\n|,/).map((s) => s.trim()).filter(Boolean) : [];
       let imgDomains = imgStored ? imgStored.split(/\r?\n|,/).map((s) => s.trim()).filter(Boolean) : [];
+      let notionPageDefault = notionStored || (typeof window.NOTION_PAGE === 'string' ? window.NOTION_PAGE : '');
       if (apiDomains.length === 0 && Array.isArray(window.API_DOMAINS)) {
         apiDomains = window.API_DOMAINS;
       }
@@ -224,7 +227,7 @@ document.addEventListener('DOMContentLoaded', () => {
         attempt();
       }
       async function fetchWithFallback(path, options = {}) {
-        const isApi = path.startsWith('/api/wx') || path.startsWith('/api/bil') || path.startsWith('/api/article') || path.startsWith('/api/daily') || path.startsWith('/a/');
+        const isApi = path.startsWith('/api/wx') || path.startsWith('/api/bil') || path.startsWith('/api/article') || path.startsWith('/api/daily') || path.startsWith('/api/notion') || path.startsWith('/a/');
         const domains = isApi ? apiDomains : imgDomains;
         for (const d of domains) {
           try {
@@ -291,6 +294,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const initialCols = isMobile ? 2 : savedCols;
       columnCountInput.value = String(initialCols);
       perPageInput.value = String(savedPerPage);
+      notionPageInput.value = notionPageDefault;
       const multiTagsSaved = localStorage.getItem('multiTags') === 'true';
       multiTagToggle.checked = multiTagsSaved;
       gallery.style.columnCount = String(initialCols);
@@ -352,6 +356,28 @@ document.addEventListener('DOMContentLoaded', () => {
         });
         observer.observe(img);
         return img;
+      }
+
+      function parseNotionRows(rows) {
+        const result = {};
+        rows.forEach((row) => {
+          const entries = Object.entries(row).filter(([k]) => !k.startsWith('_'));
+          if (!entries.length) return;
+          const title = String(entries[0][1]);
+          let description = '';
+          const images = [];
+          for (const [k, v] of entries.slice(1)) {
+            if (!description && /desc|description|\u63cf\u8ff0/i.test(k)) {
+              description = String(v);
+            }
+            if (/image|img|\u56fe\u7247|cover/i.test(k)) {
+              if (Array.isArray(v)) images.push(...v.filter((s) => typeof s === 'string'));
+              else if (typeof v === 'string') images.push(v);
+            }
+          }
+          result[title] = { description, images };
+        });
+        return result;
       }
 
       function createCard(item) {
@@ -591,7 +617,20 @@ document.addEventListener('DOMContentLoaded', () => {
         } catch (e) {
           console.error("加载 bilibili 失败:", e);
         }
-        return Object.assign({}, dataWx, dataBil);
+        let notionData = {};
+        const notionUrl = notionPageInput.value.trim();
+        if (notionUrl) {
+          try {
+            const resNotion = await fetchWithFallback(`/api/notion?url=${encodeURIComponent(notionUrl)}`, { headers: { 'x-skip-cache': '1' } });
+            if (resNotion.ok) {
+              const rows = await resNotion.json();
+              notionData = parseNotionRows(rows);
+            }
+          } catch (e) {
+            console.error("加载 Notion 失败:", e);
+          }
+        }
+        return Object.assign({}, dataWx, dataBil, notionData);
       }
       async function fetchDaily() {
         const res = await fetchWithFallback("/api/daily", {
@@ -712,6 +751,9 @@ document.addEventListener('DOMContentLoaded', () => {
       applySettings.addEventListener('click', () => {
         const cols = Math.max(1, parseInt(columnCountInput.value) || 1);
         perPage = Math.max(1, parseInt(perPageInput.value) || 1);
+        const notionVal = notionPageInput.value.trim();
+        if (notionVal) localStorage.setItem('notionPage', notionVal);
+        else localStorage.removeItem('notionPage');
         gallery.style.columnCount = String(cols);
         localStorage.setItem('columnCount', String(cols));
         localStorage.setItem('perPage', String(perPage));

--- a/main.html
+++ b/main.html
@@ -65,6 +65,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const applySettings = document.getElementById('applySettings');
       const columnCountInput = document.getElementById('columnCountInput');
       const perPageInput = document.getElementById('perPageInput');
+      const notionPageInput = document.getElementById('notionPageInput');
       const multiTagToggle = document.getElementById('multiTagToggle');
       const clearCacheBtn = document.getElementById('clearCache');
       const imageModal = document.getElementById('imageModal');
@@ -72,10 +73,12 @@ document.addEventListener('DOMContentLoaded', () => {
       let imgScale = 1;
       const apiStored = localStorage.getItem('apiDomains') || localStorage.getItem('apiDomain') || '';
       const imgStored = localStorage.getItem('imgDomains') || '';
+      const notionStored = localStorage.getItem('notionPage') || '';
       let apiDomains = apiStored ?
         apiStored.split(/\r?\n|,/).map((s) => s.trim()).filter(Boolean) : [];
       let imgDomains = imgStored ?
         imgStored.split(/\r?\n|,/).map((s) => s.trim()).filter(Boolean) : [];
+      let notionPageDefault = notionStored || (typeof window.NOTION_PAGE === 'string' ? window.NOTION_PAGE : '');
       if (apiDomains.length === 0 && Array.isArray(window.API_DOMAINS)) {
         apiDomains = window.API_DOMAINS;
       }
@@ -105,7 +108,7 @@ document.addEventListener('DOMContentLoaded', () => {
         attempt();
       }
       async function fetchWithFallback(path, options = {}) {
-        const isApi = path.startsWith('/api/wx') || path.startsWith('/api/bil') || path.startsWith('/api/wx.json') || path.startsWith('/api/daily') || path.startsWith('/a/');
+        const isApi = path.startsWith('/api/wx') || path.startsWith('/api/bil') || path.startsWith('/api/wx.json') || path.startsWith('/api/daily') || path.startsWith('/api/notion') || path.startsWith('/a/');
         const domains = isApi ? apiDomains : imgDomains;
         for (const d of domains) {
           try {
@@ -154,6 +157,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const initialCols = isMobile ? 2 : savedCols;
       columnCountInput.value = String(initialCols);
       perPageInput.value = String(savedPerPage);
+      notionPageInput.value = notionPageDefault;
       const multiTagsSaved = localStorage.getItem('multiTags') === 'true';
       multiTagToggle.checked = multiTagsSaved;
       gallery.style.columnCount = String(initialCols);
@@ -215,6 +219,28 @@ document.addEventListener('DOMContentLoaded', () => {
         observer.observe(img);
         img.addEventListener('click', () => openImage(img.src || buildUrl(img.dataset.path, imgDomains[0])));
         return img;
+      }
+
+      function parseNotionRows(rows) {
+        const result = {};
+        rows.forEach((row) => {
+          const entries = Object.entries(row).filter(([k]) => !k.startsWith('_'));
+          if (!entries.length) return;
+          const title = String(entries[0][1]);
+          let description = '';
+          const images = [];
+          for (const [k, v] of entries.slice(1)) {
+            if (!description && /desc|description|\u63cf\u8ff0/i.test(k)) {
+              description = String(v);
+            }
+            if (/image|img|\u56fe\u7247|cover/i.test(k)) {
+              if (Array.isArray(v)) images.push(...v.filter((s) => typeof s === 'string'));
+              else if (typeof v === 'string') images.push(v);
+            }
+          }
+          result[title] = { description, images };
+        });
+        return result;
       }
 
       function buildItems(data) {
@@ -349,7 +375,20 @@ document.addEventListener('DOMContentLoaded', () => {
         } catch (e) {
           console.error('加载 bilibili 失败:', e);
         }
-        return Object.assign({}, dataWx, dataBil);
+        let notionData = {};
+        const notionUrl = notionPageInput.value.trim();
+        if (notionUrl) {
+          try {
+            const resNotion = await fetchWithFallback(`/api/notion?url=${encodeURIComponent(notionUrl)}`, { headers: { 'x-skip-cache': '1' } });
+            if (resNotion.ok) {
+              const rows = await resNotion.json();
+              notionData = parseNotionRows(rows);
+            }
+          } catch (e) {
+            console.error('加载 Notion 失败:', e);
+          }
+        }
+        return Object.assign({}, dataWx, dataBil, notionData);
       }
       async function hasWxCache() {
         if (!("caches" in window)) return false;
@@ -432,6 +471,9 @@ document.addEventListener('DOMContentLoaded', () => {
       applySettings.addEventListener('click', () => {
         const cols = Math.max(1, parseInt(columnCountInput.value) || 1);
         perPage = Math.max(1, parseInt(perPageInput.value) || 1);
+        const notionVal = notionPageInput.value.trim();
+        if (notionVal) localStorage.setItem('notionPage', notionVal);
+        else localStorage.removeItem('notionPage');
         gallery.style.columnCount = String(cols);
         localStorage.setItem('columnCount', String(cols));
         localStorage.setItem('perPage', String(perPage));

--- a/server.ts
+++ b/server.ts
@@ -5,7 +5,7 @@ import {
   fromFileUrl,
   join,
 } from "https://deno.land/std@0.224.0/path/mod.ts";
-import cheerio from "npm:cheerio@1.0.0-rc.12";
+import cheerio from "https://esm.sh/cheerio@1.0.0-rc.12";
 
 const CORS_HEADERS = {
   "Access-Control-Allow-Origin": "*",

--- a/static/settings.html
+++ b/static/settings.html
@@ -44,6 +44,14 @@
             class="mt-1 w-full border rounded p-1 bg-surface text-on-surface"
           />
         </label>
+        <label class="block text-sm">Notion 页面链接
+          <input
+            id="notionPageInput"
+            type="text"
+            placeholder="https://www.notion.so/..."
+            class="mt-1 w-full border rounded p-1 bg-surface text-on-surface"
+          />
+        </label>
         <button id="applySettings" class="w-full bg-primary text-white py-1 rounded">应用</button>
         <button id="clearCache" class="w-full bg-red-500 text-white py-1 rounded">清理缓存</button>
         <footer class="text-xs text-center text-gray-400 my-4 dark:text-gray-300">

--- a/static/sw.js
+++ b/static/sw.js
@@ -25,7 +25,7 @@ self.addEventListener("activate", (event) => {
 });
 self.addEventListener("fetch", (event) => {
   const url = new URL(event.request.url);
-  if (url.pathname === "/api/wx" || url.pathname === "/api/bil" || url.pathname === "/api/daily") {
+  if (url.pathname === "/api/wx" || url.pathname === "/api/bil" || url.pathname === "/api/daily" || url.pathname === "/api/notion") {
     if (event.request.headers.get("x-skip-cache")) {
       event.respondWith(fetchAndCache(event.request));
     } else {


### PR DESCRIPTION
## Summary
- allow users to input a Notion page link in settings
- fetch table data from Notion via `/api/notion`
- merge Notion rows into gallery rendering
- inject `NOTION_PAGE` setting
- update service worker and build scripts

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_685fcee71cb0832e982b74e3b7ff876e