### PR TITLE
Add Notion table support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 | 变量 | 默认值 | 说明 |
 | --- | --- | --- |
 | `WX_URL` | `必填` | 获取的微信公众号文章列表，如果不填会从本地 `article.txt` 读取 |
+| `NOTION_PAGE_ID` | `可选` | 公开的 Notion 表格页面 ID，用于额外的图集数据 |
 | `API_DOMAINS` | `可选` | 提供 `/api/wx`、`/api/article` 和 `/api/daily` 的备用域名，多个域名用逗号或空格分隔 |
 | `IMG_DOMAINS` | `可选` | 图片代理 `/img` 的备用域名，多个域名用逗号或空格分隔 |
 
@@ -35,7 +36,7 @@ date: 2024-01-01 12:00:00
 
 项目中的 HTML 与文本文件会在构建时作为字符串引入，规则已在 `wrangler.toml` 中配置。
 
-Workers 会读取 `WX_URL`、`API_DOMAINS` 和 `IMG_DOMAINS` 这几个环境变量。
+Workers 会读取 `WX_URL`、`NOTION_PAGE_ID`、`API_DOMAINS` 和 `IMG_DOMAINS` 这几个环境变量。
 
 ## 构建静态站点并部署到 GitHub Pages
 

--- a/ideas.html
+++ b/ideas.html
@@ -224,7 +224,7 @@ document.addEventListener('DOMContentLoaded', () => {
         attempt();
       }
       async function fetchWithFallback(path, options = {}) {
-        const isApi = path.startsWith('/api/wx') || path.startsWith('/api/bil') || path.startsWith('/api/article') || path.startsWith('/api/daily') || path.startsWith('/a/');
+        const isApi = path.startsWith('/api/wx') || path.startsWith('/api/bil') || path.startsWith('/api/notion') || path.startsWith('/api/article') || path.startsWith('/api/daily') || path.startsWith('/a/');
         const domains = isApi ? apiDomains : imgDomains;
         for (const d of domains) {
           try {
@@ -582,6 +582,15 @@ document.addEventListener('DOMContentLoaded', () => {
           headers: { "x-skip-cache": "1" },
         });
         const dataWx = resWx.ok ? await resWx.json() : {};
+        let dataNotion = {};
+        try {
+          const resNotion = await fetchWithFallback("/api/notion", {
+            headers: { "x-skip-cache": "1" },
+          });
+          if (resNotion.ok) dataNotion = await resNotion.json();
+        } catch (e) {
+          console.error("加载 notion 失败:", e);
+        }
         let dataBil = {};
         try {
           const resBil = await fetchWithFallback("/api/bil", {
@@ -591,7 +600,7 @@ document.addEventListener('DOMContentLoaded', () => {
         } catch (e) {
           console.error("加载 bilibili 失败:", e);
         }
-        return Object.assign({}, dataWx, dataBil);
+        return Object.assign({}, dataWx, dataBil, dataNotion);
       }
       async function fetchDaily() {
         const res = await fetchWithFallback("/api/daily", {

--- a/main.html
+++ b/main.html
@@ -105,7 +105,7 @@ document.addEventListener('DOMContentLoaded', () => {
         attempt();
       }
       async function fetchWithFallback(path, options = {}) {
-        const isApi = path.startsWith('/api/wx') || path.startsWith('/api/bil') || path.startsWith('/api/wx.json') || path.startsWith('/api/daily') || path.startsWith('/a/');
+        const isApi = path.startsWith('/api/wx') || path.startsWith('/api/bil') || path.startsWith('/api/notion') || path.startsWith('/api/wx.json') || path.startsWith('/api/daily') || path.startsWith('/a/');
         const domains = isApi ? apiDomains : imgDomains;
         for (const d of domains) {
           try {
@@ -340,6 +340,15 @@ document.addEventListener('DOMContentLoaded', () => {
           headers: { 'x-skip-cache': '1' },
         });
         const dataWx = resWx.ok ? await resWx.json() : {};
+        let dataNotion = {};
+        try {
+          const resNotion = await fetchWithFallback('/api/notion', {
+            headers: { 'x-skip-cache': '1' },
+          });
+          if (resNotion.ok) dataNotion = await resNotion.json();
+        } catch (e) {
+          console.error('加载 notion 失败:', e);
+        }
         let dataBil = {};
         try {
           const resBil = await fetchWithFallback('/api/bil', {
@@ -349,7 +358,7 @@ document.addEventListener('DOMContentLoaded', () => {
         } catch (e) {
           console.error('加载 bilibili 失败:', e);
         }
-        return Object.assign({}, dataWx, dataBil);
+        return Object.assign({}, dataWx, dataBil, dataNotion);
       }
       async function hasWxCache() {
         if (!("caches" in window)) return false;

--- a/static/sw.js
+++ b/static/sw.js
@@ -25,7 +25,7 @@ self.addEventListener("activate", (event) => {
 });
 self.addEventListener("fetch", (event) => {
   const url = new URL(event.request.url);
-  if (url.pathname === "/api/wx" || url.pathname === "/api/bil" || url.pathname === "/api/daily") {
+  if (url.pathname === "/api/wx" || url.pathname === "/api/bil" || url.pathname === "/api/daily" || url.pathname === "/api/notion") {
     if (event.request.headers.get("x-skip-cache")) {
       event.respondWith(fetchAndCache(event.request));
     } else {


### PR DESCRIPTION
## Summary
- allow configuring a NOTION_PAGE_ID
- fetch Notion rows in Node/Deno/Worker servers
- expose `/api/notion` endpoint
- load Notion data on the main gallery and article pages
- cache `/api/notion` in the service worker

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_685fe761a558832e8e89dfd6b16e65d4