### PR TITLE
Add Chrome extension for local wx api generation

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -1,0 +1,100 @@
+const fallbackSentences = [
+  "两只黄鹂鸣翠柳",
+  "一行白鹭上青天",
+  "窗含西岭千秋雪",
+  "门泊东吴万里船",
+];
+
+function randomSentence() {
+  return fallbackSentences[Math.floor(Math.random() * fallbackSentences.length)];
+}
+
+function parseArticles(text) {
+  const trimmed = text.trim();
+  if (!trimmed.startsWith('---')) {
+    return trimmed.split(/\r?\n/).map(l => ({ url: l.trim() })).filter(a => a.url);
+  }
+  const parts = trimmed.split(/^---\s*$/m).map(p => p.trim()).filter(Boolean);
+  const arr = [];
+  for (const part of parts) {
+    const lines = part.split(/\r?\n/);
+    const meta = {};
+    let current = null;
+    for (const line of lines) {
+      const kv = line.match(/^(\w+):\s*(.*)$/);
+      if (kv) {
+        current = kv[1];
+        const value = kv[2];
+        if (value === '') {
+          meta[current] = current === 'tags' ? [] : '';
+        } else {
+          meta[current] = value;
+        }
+        continue;
+      }
+      const m = line.match(/^\s*-\s*(.+)$/);
+      if (m && current) {
+        if (!Array.isArray(meta[current])) meta[current] = [];
+        meta[current].push(m[1]);
+      }
+    }
+    if (meta.url) arr.push(meta);
+  }
+  return arr;
+}
+
+async function fetchArticleData(article) {
+  try {
+    const res = await fetch(article.url);
+    const html = await res.text();
+    const doc = new DOMParser().parseFromString(html, 'text/html');
+    const title = article.title ||
+      doc.querySelector('#activity-name')?.textContent.trim() ||
+      doc.querySelector('.rich_media_title')?.textContent.trim() ||
+      randomSentence();
+    const time = article.date ||
+      doc.querySelector('#publish_time')?.textContent.trim() ||
+      doc.querySelector('meta[property="article:published_time"]')?.content?.trim();
+    const description = article.describe ||
+      doc.querySelector('meta[property="og:description"]')?.content?.trim() ||
+      doc.querySelector('#js_content p')?.textContent.trim();
+    const images = Array.from(doc.querySelectorAll('#js_content img')).map(img => {
+      const src = img.getAttribute('data-src') || img.getAttribute('src');
+      return src ? src.split('?')[0] : null;
+    }).filter(Boolean);
+    const jsonWxEl = doc.querySelector('catch#json-wx');
+    let jsonWx;
+    if (jsonWxEl) {
+      const raw = jsonWxEl.innerHTML.trim();
+      if (raw) {
+        try {
+          jsonWx = JSON.parse(raw.replace(/&quot;/g, '"'));
+        } catch (e) {
+          jsonWx = { parseError: e.message, raw };
+        }
+      }
+    }
+    return { [title]: { time, description, images, jsonWx, url: article.url, tags: article.tags, abbrlink: article.abbrlink, date: article.date } };
+  } catch (e) {
+    return { [`(抓取失败) ${article.url}`]: { error: String(e) } };
+  }
+}
+
+chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+  if (msg.type === 'generateWxApi') {
+    (async () => {
+      let { articleText } = await chrome.storage.local.get('articleText');
+      if (!articleText) {
+        sendResponse({ error: 'No article.txt loaded' });
+        return;
+      }
+      const articles = parseArticles(articleText);
+      const wxArticles = articles.filter(a => a.url.includes('mp.weixin.qq.com'));
+      const results = await Promise.all(wxArticles.map(fetchArticleData));
+      const merged = {};
+      results.forEach(r => Object.assign(merged, r));
+      sendResponse({ data: merged });
+    })();
+    return true; // keep the channel open
+  }
+});

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,14 @@
+{
+  "manifest_version": 3,
+  "name": "WX API Generator",
+  "description": "Generate /api/wx from local article.txt",
+  "version": "1.0",
+  "permissions": ["storage"],
+  "host_permissions": ["<all_urls>"],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "action": {
+    "default_popup": "popup.html"
+  }
+}

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>WX API Generator</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 1em; }
+    pre { white-space: pre-wrap; word-break: break-all; }
+  </style>
+</head>
+<body>
+  <input type="file" id="fileInput" accept=".txt">
+  <button id="generateBtn">Generate</button>
+  <pre id="result"></pre>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1,0 +1,20 @@
+document.getElementById('fileInput').addEventListener('change', (e) => {
+  const file = e.target.files[0];
+  if (!file) return;
+  const reader = new FileReader();
+  reader.onload = () => {
+    chrome.storage.local.set({ articleText: reader.result });
+  };
+  reader.readAsText(file);
+});
+
+document.getElementById('generateBtn').addEventListener('click', () => {
+  chrome.runtime.sendMessage({ type: 'generateWxApi' }, (res) => {
+    const pre = document.getElementById('result');
+    if (res && res.data) {
+      pre.textContent = JSON.stringify(res.data, null, 2);
+    } else {
+      pre.textContent = 'Failed to generate';
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add a small Chrome/Edge extension in `extension/`
- popup UI lets user load a local `article.txt` file
- background script parses the file and fetches article details
- generated data returned via message

## Testing
- `npm run build`
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68608b4c8394832e8a96334899d1e481