### PR TITLE
Add Chrome extension for local scraping

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -1,0 +1,110 @@
+// Background service worker for Flow WX Scraper
+
+// Parse article.txt format into an array of article metadata
+function parseArticles(text) {
+  const trimmed = text.trim();
+  if (!trimmed.startsWith('---')) {
+    return trimmed
+      .split(/\r?\n/)
+      .map(l => ({ url: l.trim() }))
+      .filter(a => a.url);
+  }
+  const parts = trimmed.split(/^---\s*$/m).map(p => p.trim()).filter(Boolean);
+  const arr = [];
+  for (const part of parts) {
+    const lines = part.split(/\r?\n/);
+    const meta = {};
+    let current = null;
+    for (const line of lines) {
+      const kv = line.match(/^([\w]+):\s*(.*)$/);
+      if (kv) {
+        current = kv[1];
+        const value = kv[2];
+        if (value === '') {
+          if (current === 'tags') meta[current] = [];
+          else meta[current] = '';
+        } else {
+          meta[current] = value;
+        }
+        continue;
+      }
+      const m = line.match(/^\s*-\s*(.+)$/);
+      if (m && current) {
+        if (!Array.isArray(meta[current])) meta[current] = [];
+        meta[current].push(m[1]);
+      }
+    }
+    if (meta.url) arr.push(meta);
+  }
+  return arr;
+}
+
+// Fetch title if not provided
+async function fetchTitle(url) {
+  const res = await fetch(url);
+  const html = await res.text();
+  const doc = new DOMParser().parseFromString(html, 'text/html');
+  const t = doc.querySelector('#activity-name')?.textContent?.trim() ||
+            doc.querySelector('.rich_media_title')?.textContent?.trim() ||
+            doc.querySelector('.opus-module-title__text')?.textContent?.trim() ||
+            '';
+  return t || 'Untitled';
+}
+
+// Scrape article details
+async function scrape(article) {
+  const res = await fetch(article.url);
+  const html = await res.text();
+  const doc = new DOMParser().parseFromString(html, 'text/html');
+  const name = article.title && article.title.trim() !== ''
+    ? article.title
+    : doc.querySelector('#activity-name')?.textContent?.trim() ||
+      doc.querySelector('.rich_media_title')?.textContent?.trim() ||
+      doc.querySelector('.opus-module-title__text')?.textContent?.trim() ||
+      'Untitled';
+  const time = article.date ||
+    doc.querySelector('#publish_time')?.textContent?.trim() ||
+    doc.querySelector('meta[property="article:published_time"]')?.getAttribute('content') ||
+    '';
+  const description = article.describe ||
+    doc.querySelector('meta[property="og:description"]')?.getAttribute('content') ||
+    doc.querySelector('#js_content p')?.textContent?.trim() ||
+    '';
+  const images = Array.from(doc.querySelectorAll('#js_content img'))
+    .map(img => (img.getAttribute('data-src') || img.getAttribute('src'))?.split('?')[0])
+    .filter(Boolean);
+  return { [name]: { time, description, images, url: article.url, tags: article.tags, abbrlink: article.abbrlink, date: article.date } };
+}
+
+// Process article text, fetch data and store in chrome.storage
+async function processArticleText(text) {
+  const articles = parseArticles(text);
+  for (const art of articles) {
+    if (!art.title || (Array.isArray(art.title) && art.title.length === 0) || (typeof art.title === 'string' && art.title.trim() === '')) {
+      art.title = await fetchTitle(art.url);
+    }
+  }
+  const result = {};
+  for (const art of articles) {
+    try {
+      const data = await scrape(art);
+      Object.assign(result, data);
+    } catch (e) {
+      result[`(fetch error) ${art.url}`] = { error: String(e) };
+    }
+  }
+  await chrome.storage.local.set({ wxData: result });
+}
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.type === 'processArticleFile') {
+    processArticleText(message.text).then(() => sendResponse({ ok: true }));
+    return true; // async
+  }
+  if (message.type === 'getWxData') {
+    chrome.storage.local.get('wxData').then(data => {
+      sendResponse({ data: data.wxData || {} });
+    });
+    return true;
+  }
+});

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,23 @@
+{
+  "manifest_version": 3,
+  "name": "Flow WX Scraper",
+  "description": "Scrape WeChat articles from a local article.txt and provide /wx/api",
+  "version": "1.0",
+  "permissions": ["storage"],
+  "host_permissions": [
+    "https://mp.weixin.qq.com/*",
+    "https://www.bilibili.com/*"
+  ],
+  "action": {
+    "default_popup": "popup.html"
+  },
+  "background": {
+    "service_worker": "background.js"
+  },
+  "web_accessible_resources": [
+    {
+      "resources": ["wx_api.html"],
+      "matches": ["<all_urls>"]
+    }
+  ]
+}

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Flow WX Scraper</title>
+</head>
+<body>
+  <input type="file" id="fileInput" accept=".txt">
+  <p id="status"></p>
+  <p><a href="wx_api.html" target="_blank">Open /wx/api</a></p>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1,0 +1,15 @@
+document.getElementById('fileInput').addEventListener('change', async (e) => {
+  const file = e.target.files[0];
+  if (!file) return;
+  const text = await file.text();
+  chrome.runtime.sendMessage({ type: 'processArticleFile', text }, (res) => {
+    const status = document.getElementById('status');
+    if (chrome.runtime.lastError) {
+      status.textContent = chrome.runtime.lastError.message;
+    } else if (res && res.ok) {
+      status.textContent = 'Processed successfully';
+    } else {
+      status.textContent = 'Failed to process';
+    }
+  });
+});

--- a/extension/wx_api.html
+++ b/extension/wx_api.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>/wx/api</title>
+  <style>body{font-family:monospace;white-space:pre;}</style>
+</head>
+<body>
+  <pre id="output">Loading...</pre>
+  <script>
+  chrome.runtime.sendMessage({ type: 'getWxData' }, (res) => {
+    document.getElementById('output').textContent = JSON.stringify(res.data || {}, null, 2);
+  });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create `extension/` folder with Chrome MV3 extension
- allow selecting a local `article.txt` via popup
- scrape titles and content with a background service worker
- expose results at `wx_api.html`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68608b4c8394832e8a96334899d1e481