### PR TITLE
Update extension with tabs and caching

### DIFF
--- a/extension/popup.html
+++ b/extension/popup.html
@@ -32,9 +32,9 @@
       <button id="downloadWx">Download wx</button>
     </div>
     <div>
-      <h3>bil.json</h3>
+      <h3>bil</h3>
       <pre id="bilOutput"></pre>
-      <button id="downloadBil">Download bil.json</button>
+      <button id="downloadBil">Download bil</button>
     </div>
   </div>
   <script src="popup.js"></script>

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -6,20 +6,36 @@
   <style>
     body { font-family: sans-serif; padding: 10px; width: 320px; }
     pre { white-space: pre-wrap; word-break: break-all; max-height: 300px; overflow-y: auto; }
+    .tabs { display: flex; margin-bottom: 6px; }
+    .tab { flex: 1; padding: 4px; text-align: center; border: 1px solid #ccc; cursor: pointer; }
+    .tab.active { background: #eee; }
+    .tab + .tab { border-left: none; }
+    .tab-content { display: none; }
+    .tab-content.active { display: block; }
+    textarea { width: 100%; height: 120px; }
   </style>
 </head>
 <body>
-  <input type="file" id="fileInput" accept=".txt">
-  <button id="generateBtn">Generate</button>
-  <div>
-    <h3>wx</h3>
-    <pre id="wxOutput"></pre>
-    <button id="downloadWx">Download wx</button>
+  <div class="tabs">
+    <div class="tab active" data-tab="edit">文章</div>
+    <div class="tab" data-tab="result">结果</div>
   </div>
-  <div>
-    <h3>bil.json</h3>
-    <pre id="bilOutput"></pre>
-    <button id="downloadBil">Download bil.json</button>
+  <div id="editTab" class="tab-content active">
+    <input type="file" id="fileInput" accept=".txt">
+    <textarea id="articleText" placeholder="article.txt 内容"></textarea>
+    <button id="generateBtn">Generate</button>
+  </div>
+  <div id="resultTab" class="tab-content">
+    <div>
+      <h3>wx</h3>
+      <pre id="wxOutput"></pre>
+      <button id="downloadWx">Download wx</button>
+    </div>
+    <div>
+      <h3>bil.json</h3>
+      <pre id="bilOutput"></pre>
+      <button id="downloadBil">Download bil.json</button>
+    </div>
   </div>
   <script src="popup.js"></script>
 </body>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -102,13 +102,40 @@ async function scrapeBili(article) {
   };
 }
 
+function switchTab(name) {
+  document.querySelectorAll('.tab').forEach(t => {
+    t.classList.toggle('active', t.dataset.tab === name);
+  });
+  document.querySelectorAll('.tab-content').forEach(c => {
+    c.classList.toggle('active', c.id === name + 'Tab');
+  });
+}
+
+document.querySelectorAll('.tab').forEach(t => {
+  t.addEventListener('click', () => switchTab(t.dataset.tab));
+});
+
+document.addEventListener('DOMContentLoaded', () => {
+  chrome.storage.local.get('articleText', res => {
+    if (res.articleText) document.getElementById('articleText').value = res.articleText;
+  });
+});
+
+document.getElementById('fileInput').addEventListener('change', async (e) => {
+  const file = e.target.files[0];
+  if (!file) return;
+  const text = await file.text();
+  document.getElementById('articleText').value = text;
+  chrome.storage.local.set({ articleText: text });
+});
+
 document.getElementById('generateBtn').addEventListener('click', async () => {
-  const file = document.getElementById('fileInput').files[0];
-  if (!file) {
-    alert('Please select article.txt');
+  const text = document.getElementById('articleText').value.trim();
+  if (!text) {
+    alert('Please input article.txt');
     return;
   }
-  const text = await file.text();
+  chrome.storage.local.set({ articleText: text });
   const articles = parseArticles(text);
   const wxArticles = articles.filter(a => a.url.includes('mp.weixin.qq.com'));
   const bilArticles = articles.filter(a => a.url.includes('bilibili.com'));
@@ -139,6 +166,7 @@ document.getElementById('generateBtn').addEventListener('click', async () => {
 
   window.currentWx = wxMerged;
   window.currentBil = bilMerged;
+  switchTab('result');
 });
 
 document.getElementById('downloadWx').addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- add tab navigation and textarea to popup.html
- cache selected article.txt in `chrome.storage`
- update popup.js to use stored text and show results in a second tab

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6860959262c8832ea0153e0da4dc7652