### PR TITLE
Add side panel support and UI actions

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -5,6 +5,10 @@
   "version": "1.0",
   "permissions": ["storage"],
   "host_permissions": ["*://*/*"],
+  "side_panel": {
+    "default_path": "popup.html"
+  },
+  "options_page": "options.html",
   "action": {
     "default_popup": "popup.html"
   }

--- a/extension/options.html
+++ b/extension/options.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Flow WX Settings</title>
+  <style>
+    body { font-family: sans-serif; padding: 10px; }
+  </style>
+</head>
+<body>
+  <h2>Settings</h2>
+  <p>Nothing here yet.</p>
+</body>
+</html>

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -6,10 +6,12 @@
   <style>
     body { font-family: sans-serif; padding: 10px; width: 320px; }
     pre { white-space: pre-wrap; word-break: break-all; max-height: 300px; overflow-y: auto; }
-    .tabs { display: flex; margin-bottom: 6px; }
+    .tabs { display: flex; align-items: center; margin-bottom: 6px; }
     .tab { flex: 1; padding: 4px; text-align: center; border: 1px solid #ccc; cursor: pointer; }
     .tab.active { background: #eee; }
     .tab + .tab { border-left: none; }
+    .tab-actions { margin-left: auto; display: flex; gap: 4px; }
+    .tab-actions button { cursor: pointer; }
     .tab-content { display: none; }
     .tab-content.active { display: block; }
     textarea { width: 100%; height: 120px; }
@@ -19,6 +21,10 @@
   <div class="tabs">
     <div class="tab active" data-tab="edit">文章</div>
     <div class="tab" data-tab="result">结果</div>
+    <div class="tab-actions">
+      <button id="fullscreenBtn" title="Fullscreen">⛶</button>
+      <button id="settingsBtn" title="Settings">⚙</button>
+    </div>
   </div>
   <div id="editTab" class="tab-content active">
     <input type="file" id="fileInput" accept=".txt">

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -192,11 +192,11 @@ document.getElementById('downloadBil').addEventListener('click', () => {
 });
 
 document.getElementById('fullscreenBtn').addEventListener('click', () => {
-  chrome.windows.create({
-    url: chrome.runtime.getURL('popup.html'),
-    type: 'popup',
-    state: 'maximized'
-  });
+  if (chrome.runtime.openIndexPage) {
+    chrome.runtime.openIndexPage();
+  } else {
+    window.open(chrome.runtime.getURL('popup.html'));
+  }
 });
 
 document.getElementById('settingsBtn').addEventListener('click', () => {

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -190,3 +190,19 @@ document.getElementById('downloadBil').addEventListener('click', () => {
   a.click();
   URL.revokeObjectURL(url);
 });
+
+document.getElementById('fullscreenBtn').addEventListener('click', () => {
+  chrome.windows.create({
+    url: chrome.runtime.getURL('popup.html'),
+    type: 'popup',
+    state: 'maximized'
+  });
+});
+
+document.getElementById('settingsBtn').addEventListener('click', () => {
+  if (chrome.runtime.openOptionsPage) {
+    chrome.runtime.openOptionsPage();
+  } else {
+    window.open(chrome.runtime.getURL('options.html'));
+  }
+});


### PR DESCRIPTION
## Summary
- allow opening the extension in the browser side panel
- add options page
- add fullscreen and settings buttons to the popup

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68609d0b1b30832e9497661f75171fdf