### PR TITLE
Add article list editor to extension

### DIFF
--- a/extension/popup.html
+++ b/extension/popup.html
@@ -15,6 +15,15 @@
     .tab-content { display: none; }
     .tab-content.active { display: block; }
     textarea { width: 100%; height: 120px; }
+    .article-manager { display: flex; gap: 6px; margin-top: 6px; }
+    .article-list { width: 80px; border: 1px solid #ccc; padding: 4px; overflow-y: auto; max-height: 200px; }
+    .list-actions { display: flex; gap: 4px; margin-bottom: 4px; }
+    .article-list li { cursor: pointer; margin: 2px 0; }
+    .article-list li.active { background: #eee; }
+    .article-detail { flex: 1; }
+    .article-detail .row { display: flex; align-items: center; margin-bottom: 4px; }
+    .article-detail .row span { width: 60px; }
+    .article-detail input { flex: 1; }
   </style>
 </head>
 <body>
@@ -28,7 +37,24 @@
   </div>
   <div id="editTab" class="tab-content active">
     <input type="file" id="fileInput" accept=".txt">
-    <textarea id="articleText" placeholder="article.txt 内容"></textarea>
+    <textarea id="articleText" placeholder="article.txt 内容" style="display:none;"></textarea>
+    <div id="articleManager" class="article-manager" style="display:none;">
+      <div class="article-list">
+        <div class="list-actions">
+          <button id="addArticle">+</button>
+          <button id="deleteArticle" title="Delete">-</button>
+        </div>
+        <ul id="articleList"></ul>
+      </div>
+      <div class="article-detail" id="detailContainer">
+        <div class="row"><span>url:</span><input id="detailUrl"></div>
+        <div class="row"><span>title:</span><input id="detailTitle"></div>
+        <div class="row"><span>tags:</span><input id="detailTags"></div>
+        <div class="row"><span>abbrlink:</span><input id="detailAbbrlink"></div>
+        <div class="row"><span>describe:</span><input id="detailDescribe"></div>
+        <div class="row"><span>date:</span><input id="detailDate"></div>
+      </div>
+    </div>
     <button id="generateBtn">Generate</button>
   </div>
   <div id="resultTab" class="tab-content">

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -33,6 +33,77 @@ function parseArticles(text) {
   return arr;
 }
 
+function serializeArticles(arr) {
+  return arr.map(a => {
+    const lines = [
+      '---',
+      `url: ${a.url || ''}`,
+      `title: ${a.title || ''}`,
+      'tags:'
+    ];
+    if (Array.isArray(a.tags)) {
+      a.tags.forEach(t => lines.push(`  - ${t}`));
+    }
+    lines.push(`abbrlink: ${a.abbrlink || ''}`);
+    lines.push(`describe: ${a.describe || ''}`);
+    lines.push(`date: ${a.date || ''}`);
+    lines.push('---');
+    return lines.join('\n');
+  }).join('\n\n');
+}
+
+let articleArr = [];
+let currentIndex = -1;
+
+function sortArticles() {
+  articleArr.sort((a, b) => {
+    const aLink = (a.abbrlink || '').toString();
+    const bLink = (b.abbrlink || '').toString();
+    return aLink.localeCompare(bLink);
+  });
+}
+
+function renderList() {
+  sortArticles();
+  const listEl = document.getElementById('articleList');
+  listEl.innerHTML = '';
+  articleArr.forEach((a, i) => {
+    const li = document.createElement('li');
+    li.textContent = a.abbrlink || '(none)';
+    li.dataset.index = i;
+    if (i === currentIndex) li.classList.add('active');
+    li.addEventListener('click', () => selectArticle(i));
+    listEl.appendChild(li);
+  });
+}
+
+function selectArticle(i) {
+  currentIndex = i;
+  renderList();
+  const art = articleArr[i];
+  if (!art) return;
+  document.getElementById('detailUrl').value = art.url || '';
+  document.getElementById('detailTitle').value = art.title || '';
+  document.getElementById('detailTags').value = Array.isArray(art.tags) ? art.tags.join(',') : '';
+  document.getElementById('detailAbbrlink').value = art.abbrlink || '';
+  document.getElementById('detailDescribe').value = art.describe || '';
+  document.getElementById('detailDate').value = art.date || '';
+}
+
+function updateArticleText() {
+  const text = serializeArticles(articleArr);
+  document.getElementById('articleText').value = text;
+  chrome.storage.local.set({ articleText: text });
+}
+
+function loadArticlesFromText(text) {
+  articleArr = parseArticles(text);
+  sortArticles();
+  document.getElementById('articleManager').style.display = 'flex';
+  renderList();
+  if (articleArr.length) selectArticle(0);
+}
+
 function randomSentence() {
   const list = [
     '小荷才露尖尖角',
@@ -117,7 +188,10 @@ document.querySelectorAll('.tab').forEach(t => {
 
 document.addEventListener('DOMContentLoaded', () => {
   chrome.storage.local.get('articleText', res => {
-    if (res.articleText) document.getElementById('articleText').value = res.articleText;
+    if (res.articleText) {
+      document.getElementById('articleText').value = res.articleText;
+      loadArticlesFromText(res.articleText);
+    }
   });
 });
 
@@ -127,6 +201,7 @@ document.getElementById('fileInput').addEventListener('change', async (e) => {
   const text = await file.text();
   document.getElementById('articleText').value = text;
   chrome.storage.local.set({ articleText: text });
+  loadArticlesFromText(text);
 });
 
 document.getElementById('generateBtn').addEventListener('click', async () => {
@@ -206,3 +281,40 @@ document.getElementById('settingsBtn').addEventListener('click', () => {
     window.open(chrome.runtime.getURL('options.html'));
   }
 });
+
+document.getElementById('addArticle').addEventListener('click', () => {
+  articleArr.push({ url: '', title: '', tags: [], abbrlink: '', describe: '', date: '' });
+  renderList();
+  selectArticle(articleArr.length - 1);
+  updateArticleText();
+});
+
+document.getElementById('deleteArticle').addEventListener('click', () => {
+  if (currentIndex < 0) return;
+  articleArr.splice(currentIndex, 1);
+  if (currentIndex >= articleArr.length) currentIndex = articleArr.length - 1;
+  renderList();
+  if (currentIndex >= 0) selectArticle(currentIndex);
+  else {
+    // clear detail fields if no articles left
+    ['detailUrl','detailTitle','detailTags','detailAbbrlink','detailDescribe','detailDate']
+      .forEach(id => { document.getElementById(id).value = ''; });
+  }
+  updateArticleText();
+});
+
+['detailUrl','detailTitle','detailTags','detailAbbrlink','detailDescribe','detailDate']
+  .forEach(id => {
+    document.getElementById(id).addEventListener('input', () => {
+      if (currentIndex < 0) return;
+      const art = articleArr[currentIndex];
+      art.url = document.getElementById('detailUrl').value;
+      art.title = document.getElementById('detailTitle').value;
+      art.tags = document.getElementById('detailTags').value.split(/[,\n]+/).map(t => t.trim()).filter(Boolean);
+      art.abbrlink = document.getElementById('detailAbbrlink').value;
+      art.describe = document.getElementById('detailDescribe').value;
+      art.date = document.getElementById('detailDate').value;
+      updateArticleText();
+      renderList();
+    });
+  });


### PR DESCRIPTION
## Summary
- implement an article editor interface in extension
- parse and sort articles by `abbrlink`
- allow viewing and editing single article details
- sync edited articles back to storage
- add a delete button to remove selected articles

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6860a5cd3b14832ebec8e48e75df6fa8