### PR TITLE
Improve popup style and options

### DIFF
--- a/extension/popup.html
+++ b/extension/popup.html
@@ -4,21 +4,27 @@
   <meta charset="utf-8">
   <title>Flow WX Extension</title>
   <style>
-    body { font-family: sans-serif; padding: 10px; width: 320px; }
-    pre { white-space: pre-wrap; word-break: break-all; max-height: 300px; overflow-y: auto; }
+    * { box-sizing: border-box; }
+    body { font-family: system-ui, sans-serif; padding: 10px; width: 320px; background: #f5f5f5; }
+    pre { white-space: pre-wrap; word-break: break-all; max-height: 300px; overflow-y: auto; background: #fff; border: 1px solid #ccc; padding: 4px; border-radius: 4px; }
+    button { cursor: pointer; padding: 2px 6px; border: 1px solid #ccc; background: #fff; border-radius: 4px; }
+    button:hover { background: #f0f0f0; }
+    input, textarea { border: 1px solid #ccc; border-radius: 4px; padding: 2px 4px; }
     .tabs { display: flex; align-items: center; margin-bottom: 6px; }
-    .tab { flex: 1; padding: 4px; text-align: center; border: 1px solid #ccc; cursor: pointer; }
-    .tab.active { background: #eee; }
+    .tab { flex: 1; padding: 4px; text-align: center; border: 1px solid #ccc; cursor: pointer; background: #f7f7f7; border-radius: 4px 4px 0 0; }
+    .tab.active { background: #fff; }
     .tab + .tab { border-left: none; }
     .tab-actions { margin-left: auto; display: flex; gap: 4px; }
-    .tab-actions button { cursor: pointer; }
-    .tab-content { display: none; }
+    .tab-content { display: none; border: 1px solid #ccc; border-top: none; background: #fff; padding: 6px; border-radius: 0 4px 4px 4px; }
     .tab-content.active { display: block; }
     textarea { width: 100%; height: 120px; }
+    .options { display: flex; gap: 8px; margin: 4px 0; }
+    .options label { display: flex; align-items: center; gap: 2px; }
     .article-manager { display: flex; gap: 6px; margin-top: 6px; }
-    .article-list { width: 80px; border: 1px solid #ccc; padding: 4px; overflow-y: auto; max-height: 200px; }
+    .article-list { width: 80px; border: 1px solid #ccc; padding: 4px; overflow-y: auto; max-height: 200px; border-radius: 4px; background: #fff; }
+    .article-list ul { list-style: none; margin: 0; padding: 0; }
     .list-actions { display: flex; gap: 4px; margin-bottom: 4px; }
-    .article-list li { cursor: pointer; margin: 2px 0; }
+    .article-list li { cursor: pointer; margin: 2px 0; padding: 2px 4px; border-radius: 2px; }
     .article-list li.active { background: #eee; }
     .article-detail { flex: 1; }
     .article-detail .row { display: flex; align-items: center; margin-bottom: 4px; }
@@ -37,6 +43,10 @@
   </div>
   <div id="editTab" class="tab-content active">
     <input type="file" id="fileInput" accept=".txt">
+    <div class="options">
+      <label><input type="checkbox" id="wxToggle" checked> wx</label>
+      <label><input type="checkbox" id="bilToggle" checked> bil</label>
+    </div>
     <textarea id="articleText" placeholder="article.txt 内容" style="display:none;"></textarea>
     <div id="articleManager" class="article-manager" style="display:none;">
       <div class="article-list">

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -212,8 +212,10 @@ document.getElementById('generateBtn').addEventListener('click', async () => {
   }
   chrome.storage.local.set({ articleText: text });
   const articles = parseArticles(text);
-  const wxArticles = articles.filter(a => a.url.includes('mp.weixin.qq.com'));
-  const bilArticles = articles.filter(a => a.url.includes('bilibili.com'));
+  const doWx = document.getElementById('wxToggle').checked;
+  const doBil = document.getElementById('bilToggle').checked;
+  const wxArticles = doWx ? articles.filter(a => a.url.includes('mp.weixin.qq.com')) : [];
+  const bilArticles = doBil ? articles.filter(a => a.url.includes('bilibili.com')) : [];
 
   const [wxResults, bilResults] = await Promise.all([
     Promise.allSettled(wxArticles.map(scrapeWx)),


### PR DESCRIPTION
## Summary
- improve popup.html styles
- hide bullet list markers
- add checkboxes for selecting wx/bil scraping

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6860b1a2db98832ebf9168db32b0819d