### PR TITLE
Improve popup UI with options

### DIFF
--- a/extension/popup.html
+++ b/extension/popup.html
@@ -4,8 +4,19 @@
   <meta charset="utf-8">
   <title>Flow WX Extension</title>
   <style>
-    body { font-family: sans-serif; padding: 10px; width: 320px; }
-    pre { white-space: pre-wrap; word-break: break-all; max-height: 300px; overflow-y: auto; }
+    body {
+      font-family: system-ui, sans-serif;
+      padding: 10px;
+      width: 320px;
+      background: #f7f7f7;
+    }
+    button, input, select { font: inherit; }
+    pre {
+      white-space: pre-wrap;
+      word-break: break-all;
+      max-height: 300px;
+      overflow-y: auto;
+    }
     .tabs { display: flex; align-items: center; margin-bottom: 6px; }
     .tab { flex: 1; padding: 4px; text-align: center; border: 1px solid #ccc; cursor: pointer; }
     .tab.active { background: #eee; }
@@ -16,7 +27,14 @@
     .tab-content.active { display: block; }
     textarea { width: 100%; height: 120px; }
     .article-manager { display: flex; gap: 6px; margin-top: 6px; }
-    .article-list { width: 80px; border: 1px solid #ccc; padding: 4px; overflow-y: auto; max-height: 200px; }
+    .article-list {
+      width: 80px;
+      border: 1px solid #ccc;
+      padding: 4px;
+      overflow-y: auto;
+      max-height: 200px;
+    }
+    .article-list ul { list-style: none; padding: 0; margin: 0; }
     .list-actions { display: flex; gap: 4px; margin-bottom: 4px; }
     .article-list li { cursor: pointer; margin: 2px 0; }
     .article-list li.active { background: #eee; }
@@ -24,6 +42,8 @@
     .article-detail .row { display: flex; align-items: center; margin-bottom: 4px; }
     .article-detail .row span { width: 60px; }
     .article-detail input { flex: 1; }
+    .options { display: flex; gap: 8px; margin: 6px 0; }
+    .options label { display: flex; align-items: center; gap: 2px; }
   </style>
 </head>
 <body>
@@ -54,6 +74,10 @@
         <div class="row"><span>describe:</span><input id="detailDescribe"></div>
         <div class="row"><span>date:</span><input id="detailDate"></div>
       </div>
+    </div>
+    <div class="options">
+      <label><input type="checkbox" id="includeWx" checked>wx</label>
+      <label><input type="checkbox" id="includeBil" checked>bil</label>
     </div>
     <button id="generateBtn">Generate</button>
   </div>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -211,9 +211,11 @@ document.getElementById('generateBtn').addEventListener('click', async () => {
     return;
   }
   chrome.storage.local.set({ articleText: text });
+  const includeWx = document.getElementById('includeWx').checked;
+  const includeBil = document.getElementById('includeBil').checked;
   const articles = parseArticles(text);
-  const wxArticles = articles.filter(a => a.url.includes('mp.weixin.qq.com'));
-  const bilArticles = articles.filter(a => a.url.includes('bilibili.com'));
+  const wxArticles = includeWx ? articles.filter(a => a.url.includes('mp.weixin.qq.com')) : [];
+  const bilArticles = includeBil ? articles.filter(a => a.url.includes('bilibili.com')) : [];
 
   const [wxResults, bilResults] = await Promise.all([
     Promise.allSettled(wxArticles.map(scrapeWx)),
@@ -236,11 +238,11 @@ document.getElementById('generateBtn').addEventListener('click', async () => {
       bilMerged[`(抓取失败) ${bilArticles[i].url}`] = { error: String(r.reason) };
     }
   });
-  document.getElementById('wxOutput').textContent = JSON.stringify(wxMerged, null, 2);
-  document.getElementById('bilOutput').textContent = JSON.stringify(bilMerged, null, 2);
+  document.getElementById('wxOutput').textContent = includeWx ? JSON.stringify(wxMerged, null, 2) : '';
+  document.getElementById('bilOutput').textContent = includeBil ? JSON.stringify(bilMerged, null, 2) : '';
 
-  window.currentWx = wxMerged;
-  window.currentBil = bilMerged;
+  window.currentWx = includeWx ? wxMerged : null;
+  window.currentBil = includeBil ? bilMerged : null;
   switchTab('result');
 });
 


### PR DESCRIPTION
## Summary
- restyle popup.html with cleaner native look
- hide bullet marks in article list
- add checkboxes to choose scraping targets
- update popup.js to respect new checkboxes

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6860b1a2db98832ebf9168db32b0819d