### PR TITLE
Add manual save for article edits

### DIFF
--- a/extension/popup.html
+++ b/extension/popup.html
@@ -80,7 +80,7 @@
       <label><input type="checkbox" id="includeWx" checked>wx</label>
       <label><input type="checkbox" id="includeBil" checked>bil</label>
     </div>
-    <button id="generateBtn">Generate</button>
+    <button id="generateBtn">生成</button>
   </div>
   <div id="resultTab" class="tab-content">
     <div>

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -73,6 +73,7 @@
         <div class="row"><span>abbrlink:</span><input id="detailAbbrlink"></div>
         <div class="row"><span>describe:</span><input id="detailDescribe"></div>
         <div class="row"><span>date:</span><input id="detailDate"></div>
+        <div class="row" style="justify-content:flex-end"><button id="saveArticle">保存</button></div>
       </div>
     </div>
     <div class="options">

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -305,18 +305,20 @@ document.getElementById('deleteArticle').addEventListener('click', () => {
   updateArticleText();
 });
 
-['detailUrl','detailTitle','detailTags','detailAbbrlink','detailDescribe','detailDate']
-  .forEach(id => {
-    document.getElementById(id).addEventListener('input', () => {
-      if (currentIndex < 0) return;
-      const art = articleArr[currentIndex];
-      art.url = document.getElementById('detailUrl').value;
-      art.title = document.getElementById('detailTitle').value;
-      art.tags = document.getElementById('detailTags').value.split(/[,\n]+/).map(t => t.trim()).filter(Boolean);
-      art.abbrlink = document.getElementById('detailAbbrlink').value;
-      art.describe = document.getElementById('detailDescribe').value;
-      art.date = document.getElementById('detailDate').value;
-      updateArticleText();
-      renderList();
-    });
-  });
+
+document.getElementById('saveArticle').addEventListener('click', () => {
+  if (currentIndex < 0) return;
+  const art = articleArr[currentIndex];
+  art.url = document.getElementById('detailUrl').value;
+  art.title = document.getElementById('detailTitle').value;
+  art.tags = document.getElementById('detailTags').value.split(/[,\n]+/).map(t => t.trim()).filter(Boolean);
+  art.abbrlink = document.getElementById('detailAbbrlink').value;
+  art.describe = document.getElementById('detailDescribe').value;
+  art.date = document.getElementById('detailDate').value;
+  sortArticles();
+  const newIndex = articleArr.indexOf(art);
+  currentIndex = newIndex;
+  updateArticleText();
+  renderList();
+  selectArticle(currentIndex);
+});


### PR DESCRIPTION
## Summary
- add Save button to article detail pane
- update popup.js to only persist edits when Save is clicked

## Testing
- `npm run build`
- `npm start` *(terminated after launch)*

------
https://chatgpt.com/codex/tasks/task_b_6860bb9c0f08832ebd660b8425130af6