### PR TITLE
Add shared storage support

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -44,6 +44,13 @@
   <div class="mb-4"> <label class="block mb-1 font-semibold" for="apiInput">API 域名</label> <textarea id="apiInput" placeholder="https://a.com" class="border p-2 w-full h-24"></textarea> </div>
   <div class="mb-4"> <label class="block mb-1 font-semibold" for="imgInput">图片域名</label> <textarea id="imgInput" placeholder="https://img.com" class="border p-2 w-full h-24"></textarea> </div>
   <div class="mb-4"> <label class="block mb-1 font-semibold" for="tokenInput">GitHub Token</label> <input id="tokenInput" type="text" placeholder="ghp_..." class="border p-2 w-full" /> </div>
+  <div class="mb-4"> <label class="block mb-1 font-semibold" for="sourceSelect">默认数据来源</label>
+    <select id="sourceSelect" class="border p-2 w-full">
+      <option value="wxData">wxData</option>
+      <option value="wxLocal">wxLocal</option>
+      <option value="biLocal">biLocal</option>
+    </select>
+  </div>
   <button id="saveBtn" class="bg-blue-500 text-white px-4 py-2 rounded mr-2">保存</button>
   <button id="loadBtn" class="bg-gray-500 text-white px-4 py-2 rounded">加载</button>
   <div class="mt-8">
@@ -52,9 +59,11 @@
   const apiInput = document.getElementById('apiInput');
   const imgInput = document.getElementById('imgInput');
   const tokenInput = document.getElementById('tokenInput');
+  const sourceSelect = document.getElementById('sourceSelect');
   apiInput.value = localStorage.getItem('apiDomains') || localStorage.getItem('apiDomain') || '';
   imgInput.value = localStorage.getItem('imgDomains') || '';
   tokenInput.value = localStorage.getItem('githubToken') || '';
+  sourceSelect.value = localStorage.getItem('dataSource') || 'wxData';
   async function preloadInject() {
     const token = tokenInput.value.trim();
     if (!token || !('caches' in window)) return;
@@ -102,6 +111,7 @@
     localStorage.setItem('apiDomains', apiInput.value.trim());
     localStorage.setItem('imgDomains', imgInput.value.trim());
     localStorage.setItem('githubToken', tokenInput.value.trim());
+    localStorage.setItem('dataSource', sourceSelect.value);
     localStorage.removeItem('apiDomain');
     preloadInject();
     alert('已保存');

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -244,6 +244,15 @@ document.getElementById('generateBtn').addEventListener('click', async () => {
   document.getElementById('wxOutput').textContent = includeWx ? JSON.stringify(wxMerged, null, 2) : '';
   document.getElementById('bilOutput').textContent = includeBil ? JSON.stringify(bilMerged, null, 2) : '';
 
+  const combined = { ...wxMerged, ...bilMerged };
+  if (window.sharedStorage && typeof window.sharedStorage.set === 'function') {
+    window.sharedStorage.set('wxLocal', JSON.stringify(combined)).catch(() => {
+      chrome.storage.local.set({ wxLocal: combined });
+    });
+  } else {
+    chrome.storage.local.set({ wxLocal: combined });
+  }
+
   window.currentWx = includeWx ? wxMerged : null;
   window.currentBil = includeBil ? bilMerged : null;
   switchTab('result');

--- a/ideas.html
+++ b/ideas.html
@@ -307,6 +307,7 @@ document.addEventListener('DOMContentLoaded', () => {
       let selectedTags = [];
       let searchTerm = '';
       let allowMultiTags = multiTagsSaved;
+      const defaultSource = localStorage.getItem('dataSource') || 'wxData';
       multiTagToggle.addEventListener('change', () => {
         allowMultiTags = multiTagToggle.checked;
         localStorage.setItem('multiTags', allowMultiTags ? 'true' : 'false');
@@ -572,11 +573,25 @@ document.addEventListener('DOMContentLoaded', () => {
         }
       }
 
-        function applyData(data) {
-          rawData = data;
-          renderTags(collectTags(data));
-          applyFilter();
+      function applyData(data) {
+        rawData = data;
+        renderTags(collectTags(data));
+        applyFilter();
+      }
+
+      async function loadShared(key) {
+        if (window.sharedStorage && typeof window.sharedStorage.get === 'function') {
+          try {
+            const val = await window.sharedStorage.get(key);
+            if (val) return JSON.parse(val);
+          } catch {}
         }
+        const local = localStorage.getItem(key);
+        if (local) {
+          try { return JSON.parse(local); } catch {}
+        }
+        return null;
+      }
       async function fetchLatest() {
         const resWx = await fetchWithFallback("/api/wx", {
           headers: { "x-skip-cache": "1" },
@@ -613,6 +628,20 @@ document.addEventListener('DOMContentLoaded', () => {
 
       async function initGallery() {
         if (await hasWxCache()) hideSplash(true);
+        const localData = await loadShared('wxLocal');
+        if (localData) {
+          applyData(localData);
+          hideSplash();
+          return;
+        }
+        if (defaultSource === 'biLocal') {
+          const bi = await loadShared('biLocal');
+          if (bi) {
+            applyData(bi);
+            hideSplash();
+            return;
+          }
+        }
         const cachedStr = localStorage.getItem("wxData");
         let cached;
         if (cachedStr) {

--- a/main.html
+++ b/main.html
@@ -170,6 +170,7 @@ document.addEventListener('DOMContentLoaded', () => {
       let selectedTags = [];
       let searchTerm = '';
       let allowMultiTags = multiTagsSaved;
+      const defaultSource = localStorage.getItem('dataSource') || 'wxData';
       multiTagToggle.addEventListener('change', () => {
         allowMultiTags = multiTagToggle.checked;
         localStorage.setItem('multiTags', allowMultiTags ? 'true' : 'false');
@@ -335,6 +336,20 @@ document.addEventListener('DOMContentLoaded', () => {
         renderTags(collectTags(data));
         applyFilter();
       }
+
+      async function loadShared(key) {
+        if (window.sharedStorage && typeof window.sharedStorage.get === 'function') {
+          try {
+            const val = await window.sharedStorage.get(key);
+            if (val) return JSON.parse(val);
+          } catch {}
+        }
+        const local = localStorage.getItem(key);
+        if (local) {
+          try { return JSON.parse(local); } catch {}
+        }
+        return null;
+      }
       async function fetchLatest() {
         const resWx = await fetchWithFallback('/api/wx', {
           headers: { 'x-skip-cache': '1' },
@@ -361,6 +376,20 @@ document.addEventListener('DOMContentLoaded', () => {
       }
       async function initGallery() {
         if (await hasWxCache()) hideSplash(true);
+        const localData = await loadShared('wxLocal');
+        if (localData) {
+          applyData(localData);
+          hideSplash();
+          return;
+        }
+        if (defaultSource === 'biLocal') {
+          const bi = await loadShared('biLocal');
+          if (bi) {
+            applyData(bi);
+            hideSplash();
+            return;
+          }
+        }
         const cachedStr = localStorage.getItem('wxData');
         let cached;
         if (cachedStr) {


### PR DESCRIPTION
## Summary
- store combined scrape result in sharedStorage as `wxLocal`
- load `wxLocal` data in gallery and article pages when available
- add selectable data source in admin settings

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6860d453a244832eaf6b52ed9c745225