### PR TITLE
Add shared storage support for local content

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -44,6 +44,14 @@
   <div class="mb-4"> <label class="block mb-1 font-semibold" for="apiInput">API 域名</label> <textarea id="apiInput" placeholder="https://a.com" class="border p-2 w-full h-24"></textarea> </div>
   <div class="mb-4"> <label class="block mb-1 font-semibold" for="imgInput">图片域名</label> <textarea id="imgInput" placeholder="https://img.com" class="border p-2 w-full h-24"></textarea> </div>
   <div class="mb-4"> <label class="block mb-1 font-semibold" for="tokenInput">GitHub Token</label> <input id="tokenInput" type="text" placeholder="ghp_..." class="border p-2 w-full" /> </div>
+  <div class="mb-4">
+    <label class="block mb-1 font-semibold" for="sourceSelect">默认数据来源</label>
+    <select id="sourceSelect" class="border p-2 w-full">
+      <option value="wxData">wxData</option>
+      <option value="wxLocal">wxLocal</option>
+      <option value="biLocal">biLocal</option>
+    </select>
+  </div>
   <button id="saveBtn" class="bg-blue-500 text-white px-4 py-2 rounded mr-2">保存</button>
   <button id="loadBtn" class="bg-gray-500 text-white px-4 py-2 rounded">加载</button>
   <div class="mt-8">
@@ -52,9 +60,11 @@
   const apiInput = document.getElementById('apiInput');
   const imgInput = document.getElementById('imgInput');
   const tokenInput = document.getElementById('tokenInput');
+  const sourceSelect = document.getElementById('sourceSelect');
   apiInput.value = localStorage.getItem('apiDomains') || localStorage.getItem('apiDomain') || '';
   imgInput.value = localStorage.getItem('imgDomains') || '';
   tokenInput.value = localStorage.getItem('githubToken') || '';
+  sourceSelect.value = localStorage.getItem('dataSource') || 'wxData';
   async function preloadInject() {
     const token = tokenInput.value.trim();
     if (!token || !('caches' in window)) return;
@@ -102,6 +112,7 @@
     localStorage.setItem('apiDomains', apiInput.value.trim());
     localStorage.setItem('imgDomains', imgInput.value.trim());
     localStorage.setItem('githubToken', tokenInput.value.trim());
+    localStorage.setItem('dataSource', sourceSelect.value);
     localStorage.removeItem('apiDomain');
     preloadInject();
     alert('已保存');

--- a/ideas.html
+++ b/ideas.html
@@ -253,6 +253,22 @@ document.addEventListener('DOMContentLoaded', () => {
         }
       }
 
+      async function loadFromShared(key) {
+        if (window.sharedStorage && typeof window.sharedStorage.get === 'function') {
+          try {
+            const val = await window.sharedStorage.get(key);
+            if (typeof val === 'string') return JSON.parse(val);
+            if (val) return val;
+          } catch {}
+        }
+        if (chrome?.storage?.local?.get) {
+          try {
+            return await new Promise(res => chrome.storage.local.get(key, r => res(r[key])));
+          } catch {}
+        }
+        return null;
+      }
+
       function showArticle(html) {
         articleContent.innerHTML = html;
         articleModal.classList.remove("hidden");
@@ -613,12 +629,14 @@ document.addEventListener('DOMContentLoaded', () => {
 
       async function initGallery() {
         if (await hasWxCache()) hideSplash(true);
-        const cachedStr = localStorage.getItem("wxData");
-        let cached;
-        if (cachedStr) {
-          try {
-            cached = JSON.parse(cachedStr);
-          } catch {}
+        const pref = localStorage.getItem('dataSource') || 'wxData';
+        let cached = await loadFromShared('wxLocal');
+        if (!cached && pref === 'biLocal') {
+          cached = await loadFromShared('biLocal');
+        }
+        const cachedStr = localStorage.getItem('wxData');
+        if (!cached && cachedStr) {
+          try { cached = JSON.parse(cachedStr); } catch {}
         }
         if (cached) {
           applyData(cached);
@@ -627,14 +645,14 @@ document.addEventListener('DOMContentLoaded', () => {
           const latest = await fetchLatest();
           const latestStr = JSON.stringify(latest);
           if (!cachedStr) {
-            localStorage.setItem("wxData", latestStr);
-            applyData(latest);
+            localStorage.setItem('wxData', latestStr);
+            if (!cached) applyData(latest);
           } else if (latestStr !== cachedStr) {
-            localStorage.setItem("wxDataNew", latestStr);
+            localStorage.setItem('wxDataNew', latestStr);
             showDot();
           }
         } catch (err) {
-          console.error("加载画廊失败:", err);
+          console.error('加载画廊失败:', err);
         } finally {
           hideSplash();
         }

--- a/main.html
+++ b/main.html
@@ -134,6 +134,22 @@ document.addEventListener('DOMContentLoaded', () => {
         }
       }
 
+      async function loadFromShared(key) {
+        if (window.sharedStorage && typeof window.sharedStorage.get === 'function') {
+          try {
+            const val = await window.sharedStorage.get(key);
+            if (typeof val === 'string') return JSON.parse(val);
+            if (val) return val;
+          } catch {}
+        }
+        if (chrome?.storage?.local?.get) {
+          try {
+            return await new Promise(res => chrome.storage.local.get(key, r => res(r[key])));
+          } catch {}
+        }
+        return null;
+      }
+
       function openImage(src) {
         imgScale = 1;
         modalImg.src = src;
@@ -361,12 +377,14 @@ document.addEventListener('DOMContentLoaded', () => {
       }
       async function initGallery() {
         if (await hasWxCache()) hideSplash(true);
+        const pref = localStorage.getItem('dataSource') || 'wxData';
+        let cached = await loadFromShared('wxLocal');
+        if (!cached && pref === 'biLocal') {
+          cached = await loadFromShared('biLocal');
+        }
         const cachedStr = localStorage.getItem('wxData');
-        let cached;
-        if (cachedStr) {
-          try {
-            cached = JSON.parse(cachedStr);
-          } catch {}
+        if (!cached && cachedStr) {
+          try { cached = JSON.parse(cachedStr); } catch {}
         }
         if (cached) {
           applyData(cached);
@@ -376,7 +394,7 @@ document.addEventListener('DOMContentLoaded', () => {
           const latestStr = JSON.stringify(latest);
           if (!cachedStr) {
             localStorage.setItem('wxData', latestStr);
-            applyData(latest);
+            if (!cached) applyData(latest);
           } else if (latestStr !== cachedStr) {
             localStorage.setItem('wxDataNew', latestStr);
             showDot();


### PR DESCRIPTION
## Summary
- add support for `wxLocal` and `biLocal` data from shared storage
- pick default data source in admin page
- render wxLocal content in gallery and article if present

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6860d453a244832eaf6b52ed9c745225