### PR TITLE
Add shared storage support and default data source option

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -44,6 +44,14 @@
   <div class="mb-4"> <label class="block mb-1 font-semibold" for="apiInput">API 域名</label> <textarea id="apiInput" placeholder="https://a.com" class="border p-2 w-full h-24"></textarea> </div>
   <div class="mb-4"> <label class="block mb-1 font-semibold" for="imgInput">图片域名</label> <textarea id="imgInput" placeholder="https://img.com" class="border p-2 w-full h-24"></textarea> </div>
   <div class="mb-4"> <label class="block mb-1 font-semibold" for="tokenInput">GitHub Token</label> <input id="tokenInput" type="text" placeholder="ghp_..." class="border p-2 w-full" /> </div>
+  <div class="mb-4">
+    <label class="block mb-1 font-semibold" for="sourceSelect">默认数据来源</label>
+    <select id="sourceSelect" class="border p-2 w-full">
+      <option value="wxData">wxData</option>
+      <option value="wxLocal">wxLocal</option>
+      <option value="biLocal">biLocal</option>
+    </select>
+  </div>
   <button id="saveBtn" class="bg-blue-500 text-white px-4 py-2 rounded mr-2">保存</button>
   <button id="loadBtn" class="bg-gray-500 text-white px-4 py-2 rounded">加载</button>
   <div class="mt-8">
@@ -52,9 +60,11 @@
   const apiInput = document.getElementById('apiInput');
   const imgInput = document.getElementById('imgInput');
   const tokenInput = document.getElementById('tokenInput');
+  const sourceSelect = document.getElementById('sourceSelect');
   apiInput.value = localStorage.getItem('apiDomains') || localStorage.getItem('apiDomain') || '';
   imgInput.value = localStorage.getItem('imgDomains') || '';
   tokenInput.value = localStorage.getItem('githubToken') || '';
+  sourceSelect.value = localStorage.getItem('dataSource') || 'wxData';
   async function preloadInject() {
     const token = tokenInput.value.trim();
     if (!token || !('caches' in window)) return;
@@ -102,6 +112,7 @@
     localStorage.setItem('apiDomains', apiInput.value.trim());
     localStorage.setItem('imgDomains', imgInput.value.trim());
     localStorage.setItem('githubToken', tokenInput.value.trim());
+    localStorage.setItem('dataSource', sourceSelect.value);
     localStorage.removeItem('apiDomain');
     preloadInject();
     alert('已保存');

--- a/ideas.html
+++ b/ideas.html
@@ -577,6 +577,20 @@ document.addEventListener('DOMContentLoaded', () => {
           renderTags(collectTags(data));
           applyFilter();
         }
+
+      async function getSharedData(key) {
+        if (window.sharedStorage && typeof window.sharedStorage.get === 'function') {
+          try {
+            const val = await window.sharedStorage.get(key);
+            if (val) return JSON.parse(val);
+          } catch {}
+        }
+        const raw = localStorage.getItem(key);
+        if (raw) {
+          try { return JSON.parse(raw); } catch {}
+        }
+        return null;
+      }
       async function fetchLatest() {
         const resWx = await fetchWithFallback("/api/wx", {
           headers: { "x-skip-cache": "1" },
@@ -613,14 +627,24 @@ document.addEventListener('DOMContentLoaded', () => {
 
       async function initGallery() {
         if (await hasWxCache()) hideSplash(true);
+        const pref = localStorage.getItem('dataSource') || 'wxData';
+        const wxLocal = await getSharedData('wxLocal');
+        const biLocal = await getSharedData('biLocal');
+        const combinedLocal = Object.assign({}, wxLocal || {}, biLocal || {});
+
         const cachedStr = localStorage.getItem("wxData");
         let cached;
         if (cachedStr) {
-          try {
-            cached = JSON.parse(cachedStr);
-          } catch {}
+          try { cached = JSON.parse(cachedStr); } catch {}
         }
-        if (cached) {
+
+        if (wxLocal) {
+          applyData(combinedLocal);
+        } else if (pref === 'biLocal' && biLocal) {
+          applyData(biLocal);
+        } else if (pref === 'wxLocal' && wxLocal) {
+          applyData(wxLocal);
+        } else if (cached) {
           applyData(cached);
         }
         try {
@@ -628,7 +652,7 @@ document.addEventListener('DOMContentLoaded', () => {
           const latestStr = JSON.stringify(latest);
           if (!cachedStr) {
             localStorage.setItem("wxData", latestStr);
-            applyData(latest);
+            if (!wxLocal && pref === 'wxData') applyData(latest);
           } else if (latestStr !== cachedStr) {
             localStorage.setItem("wxDataNew", latestStr);
             showDot();

--- a/main.html
+++ b/main.html
@@ -335,6 +335,20 @@ document.addEventListener('DOMContentLoaded', () => {
         renderTags(collectTags(data));
         applyFilter();
       }
+
+      async function getSharedData(key) {
+        if (window.sharedStorage && typeof window.sharedStorage.get === 'function') {
+          try {
+            const val = await window.sharedStorage.get(key);
+            if (val) return JSON.parse(val);
+          } catch {}
+        }
+        const raw = localStorage.getItem(key);
+        if (raw) {
+          try { return JSON.parse(raw); } catch {}
+        }
+        return null;
+      }
       async function fetchLatest() {
         const resWx = await fetchWithFallback('/api/wx', {
           headers: { 'x-skip-cache': '1' },
@@ -361,14 +375,24 @@ document.addEventListener('DOMContentLoaded', () => {
       }
       async function initGallery() {
         if (await hasWxCache()) hideSplash(true);
+        const pref = localStorage.getItem('dataSource') || 'wxData';
+        const wxLocal = await getSharedData('wxLocal');
+        const biLocal = await getSharedData('biLocal');
+        const combinedLocal = Object.assign({}, wxLocal || {}, biLocal || {});
+
         const cachedStr = localStorage.getItem('wxData');
         let cached;
         if (cachedStr) {
-          try {
-            cached = JSON.parse(cachedStr);
-          } catch {}
+          try { cached = JSON.parse(cachedStr); } catch {}
         }
-        if (cached) {
+
+        if (wxLocal) {
+          applyData(combinedLocal);
+        } else if (pref === 'biLocal' && biLocal) {
+          applyData(biLocal);
+        } else if (pref === 'wxLocal' && wxLocal) {
+          applyData(wxLocal);
+        } else if (cached) {
           applyData(cached);
         }
         try {
@@ -376,7 +400,7 @@ document.addEventListener('DOMContentLoaded', () => {
           const latestStr = JSON.stringify(latest);
           if (!cachedStr) {
             localStorage.setItem('wxData', latestStr);
-            applyData(latest);
+            if (!wxLocal && pref === 'wxData') applyData(latest);
           } else if (latestStr !== cachedStr) {
             localStorage.setItem('wxDataNew', latestStr);
             showDot();


### PR DESCRIPTION
## Summary
- add data source selector in admin page
- load wxLocal/biLocal from shared storage in gallery and article pages
- prefer wxLocal data when available and respect admin setting

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6860d453a244832eaf6b52ed9c745225