### PR TITLE
Enable horizontal masonry layout

### DIFF
--- a/add.html
+++ b/add.html
@@ -42,7 +42,7 @@
       <button id="newGistBtn" class="px-3 py-1 rounded-full text-sm border-2 border-transparent hover:border-primary bg-card hidden"> + </button>
     </div>
     <main class="px-4 max-w-screen-xl mx-auto pb-8">
-      <div class="masonry" id="gallery"></div>
+      <div class="masonry horizontal" id="gallery"></div>
     </main>
     <div data-include="settings.html"></div>
     <div id="articleModal" class="fixed inset-0 bg-black/50 hidden items-center justify-center z-50">

--- a/ideas.html
+++ b/ideas.html
@@ -40,7 +40,7 @@
     <div id="tagList" class="flex overflow-x-auto whitespace-nowrap gap-2 px-4 mb-4 no-scrollbar max-w-screen-xl mx-auto"></div>
     <main class="px-4 max-w-screen-xl mx-auto pb-8">
       <!-- Masonry 容器 -->
-      <div class="masonry" id="gallery"></div> <button id="loadMore" class="mt-4 mx-auto block px-4 py-2 rounded bg-gray-200 text-gray-700 hidden">
+      <div class="masonry horizontal" id="gallery"></div> <button id="loadMore" class="mt-4 mx-auto block px-4 py-2 rounded bg-gray-200 text-gray-700 hidden">
           加载更多
         </button> </main>
     <!-- 设置面板 -->

--- a/main.html
+++ b/main.html
@@ -43,7 +43,7 @@
 
     <main class="px-4 max-w-screen-xl mx-auto pb-8">
       <!-- Masonry 容器 -->
-      <div class="masonry" id="gallery"></div>
+      <div class="masonry horizontal" id="gallery"></div>
       <button id="loadMore" class="mt-4 mx-auto block px-4 py-2 rounded bg-gray-200 text-gray-700 hidden">加载更多</button>
     </main>
 

--- a/static/common.css
+++ b/static/common.css
@@ -65,6 +65,17 @@
       }
     }
 
+    /* 横向排列的磁影漫流 */
+    .masonry.horizontal {
+      writing-mode: vertical-rl;
+      transform: rotate(180deg);
+      overflow-x: auto;
+      overflow-y: hidden;
+    }
+    .masonry.horizontal > * {
+      transform: rotate(180deg);
+    }
+
     .masonry-item .card-content {
       background-color: rgb(var(--card));
       color: rgb(var(--on-surface));


### PR DESCRIPTION
## Summary
- allow gallery to use horizontal masonry
- mark `masonry` containers with new `horizontal` class

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`
- `npm start` *(fails: Cannot find package 'express')*

------
https://chatgpt.com/codex/tasks/task_b_6860f5f59498832e9e60a57d06788ead