### PR TITLE
Merge time property into date

### DIFF
--- a/build.js
+++ b/build.js
@@ -120,7 +120,7 @@ try {
           $('#activity-name').text().trim() ||
           $('.rich_media_title').text().trim() ||
           '无标题';
-        const time =
+        const date =
           article.date ||
           $('#publish_time').text().trim() ||
           $('meta[property="article:published_time"]').attr('content');
@@ -144,14 +144,13 @@ try {
         }
         return {
           [name]: {
-            time,
+            date,
             description,
             images,
             jsonWx,
             url: article.url,
             tags: article.tags,
             abbrlink: article.abbrlink,
-            date: article.date,
           },
         };
       } finally {

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -134,7 +134,7 @@ async function scrapeWx(article) {
     doc.querySelector('#activity-name')?.textContent.trim() ||
     doc.querySelector('.rich_media_title')?.textContent.trim() ||
     randomSentence();
-  const time = article.date ||
+  const date = article.date ||
     doc.querySelector('#publish_time')?.textContent.trim() ||
     doc.querySelector('meta[property="article:published_time"]')?.getAttribute('content')?.trim();
   const description = article.describe ||
@@ -151,7 +151,7 @@ async function scrapeWx(article) {
     }
   }
   return {
-    [title]: { time, description, images, jsonWx, url, tags: article.tags, abbrlink: article.abbrlink, date: article.date }
+    [title]: { date, description, images, jsonWx, url, tags: article.tags, abbrlink: article.abbrlink }
   };
 }
 

--- a/node.js
+++ b/node.js
@@ -176,7 +176,7 @@ async function scrape(article) {
     const html = await res.text();
     const $ = cheerio.load(html, { decodeEntities: false });
     const name = article.title || $('#activity-name').text().trim() || $('.rich_media_title').text().trim() || randomSentence();
-    const time = article.date || $('#publish_time').text().trim() || $('meta[property="article:published_time"]').attr('content');
+    const date = article.date || $('#publish_time').text().trim() || $('meta[property="article:published_time"]').attr('content');
     const description = article.describe || $('meta[property="og:description"]').attr('content') || $('#js_content p').first().text().trim();
     const images = [];
     $('#js_content img').each((_, el) => {
@@ -194,14 +194,13 @@ async function scrape(article) {
     }
     return {
       [name]: {
-        time,
+        date,
         description,
         images,
         jsonWx,
         url,
         tags: article.tags,
         abbrlink: article.abbrlink,
-        date: article.date,
       },
     };
   } finally {

--- a/server.ts
+++ b/server.ts
@@ -218,7 +218,7 @@ async function scrape(article: ArticleMeta) {
       $(".rich_media_title").text().trim() ||
       randomSentence();
 
-    const time = article.date ||
+    const date = article.date ||
       $("#publish_time").text().trim() ||
       $('meta[property="article:published_time"]').attr("content")?.trim();
 
@@ -245,14 +245,13 @@ async function scrape(article: ArticleMeta) {
 
     return {
       [name]: {
-        time,
+        date,
         description,
         images,
         jsonWx,
         url,
         tags: article.tags,
         abbrlink: article.abbrlink,
-        date: article.date,
       },
     };
   } finally {

--- a/worker.js
+++ b/worker.js
@@ -269,7 +269,7 @@ async function scrape(article) {
       $('#activity-name').text().trim() ||
       $('.rich_media_title').text().trim() ||
       randomSentence();
-    const time = article.date ||
+    const date = article.date ||
       $('#publish_time').text().trim() ||
       $('meta[property="article:published_time"]').attr('content')?.trim();
     const description = article.describe || $('meta[property="og:description"]').attr('content')?.trim() ||
@@ -288,7 +288,7 @@ async function scrape(article) {
         jsonWx = { parseError: e.message, raw: jsonWxRaw };
       }
     }
-    return { [name]: { time, description, images, jsonWx, url, tags: article.tags, abbrlink: article.abbrlink, date: article.date } };
+    return { [name]: { date, description, images, jsonWx, url, tags: article.tags, abbrlink: article.abbrlink } };
   } finally {
     clearTimeout(timer);
   }


### PR DESCRIPTION
## Summary
- unify article timestamp fields by merging `time` into `date`
- update worker and node code to emit only the `date` field
- adjust popup tool accordingly
- rebuild project to verify

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6862484dd9dc832e88c568241d16d246