### PR TITLE
Unify add modal with type options

### DIFF
--- a/add.html
+++ b/add.html
@@ -65,8 +65,19 @@
   </div>
     <div id="bookmarkEditModal" class="fixed inset-0 bg-black/50 hidden items-center justify-center z-50">
       <div class="bg-card text-on-surface rounded-xl w-11/12 max-w-3xl p-4 flex flex-col gap-2">
+        <select id="addTypeSelect" class="p-2 bg-[rgba(var(--on-surface),0.05)] rounded-lg text-on-surface">
+          <option value="default">默认</option>
+          <option value="gist">Gist</option>
+          <option value="mark">Mark</option>
+        </select>
+        <label class="text-sm flex items-center gap-1">
+          <input id="saveToGistCheck" type="checkbox">
+          存到gists
+        </label>
         <input id="bookmarkTitleInput" type="text" class="p-2 bg-[rgba(var(--on-surface),0.05)] rounded-lg text-on-surface" placeholder="标题">
-        <textarea id="bookmarkTextarea" class="flex-1 w-full p-2 bg-[rgba(var(--on-surface),0.05)] rounded-lg text-on-surface" placeholder="每行格式: 标题|链接"></textarea>
+        <input id="bookmarkUrlInput" type="text" class="p-2 bg-[rgba(var(--on-surface),0.05)] rounded-lg text-on-surface" placeholder="链接 可选">
+        <input id="filenameInput" type="text" class="p-2 bg-[rgba(var(--on-surface),0.05)] rounded-lg text-on-surface" placeholder="文件名 如 note.md">
+        <textarea id="bookmarkTextarea" class="flex-1 w-full p-2 bg-[rgba(var(--on-surface),0.05)] rounded-lg text-on-surface" placeholder="内容 或 每行: 标题|链接"></textarea>
         <input id="bookmarkTagsInput" type="text" class="p-2 bg-[rgba(var(--on-surface),0.05)] rounded-lg text-on-surface" placeholder="标签 用空格分隔">
         <input id="bookmarkHeightInput" type="number" min="120" class="p-2 bg-[rgba(var(--on-surface),0.05)] rounded-lg text-on-surface" placeholder="卡片高度 默认260">
         <div class="flex justify-end gap-2 mt-2">
@@ -104,9 +115,13 @@
       const deleteGistBtn = document.getElementById('deleteGist');
       const bookmarkEditModal = document.getElementById('bookmarkEditModal');
       const bookmarkTitleInput = document.getElementById('bookmarkTitleInput');
+      const bookmarkUrlInput = document.getElementById('bookmarkUrlInput');
+      const filenameInput = document.getElementById('filenameInput');
       const bookmarkTextarea = document.getElementById('bookmarkTextarea');
       const bookmarkTagsInput = document.getElementById('bookmarkTagsInput');
       const bookmarkHeightInput = document.getElementById('bookmarkHeightInput');
+      const addTypeSelect = document.getElementById('addTypeSelect');
+      const saveToGistCheck = document.getElementById('saveToGistCheck');
       const saveEditBookmark = document.getElementById('saveEditBookmark');
       const cancelEditBookmark = document.getElementById('cancelEditBookmark');
       const clearCacheBtn = document.getElementById('clearCache');
@@ -203,6 +218,88 @@
           if (t && u) return { title: t, url: u };
           return null;
         }).filter(Boolean);
+      }
+
+      function openCreateModal(type = 'default') {
+        addTypeSelect.value = type;
+        bookmarkTitleInput.value = '';
+        bookmarkUrlInput.value = '';
+        filenameInput.value = '';
+        bookmarkTextarea.value = '';
+        bookmarkTagsInput.value = '';
+        bookmarkHeightInput.value = '260';
+        saveToGistCheck.checked = false;
+        editIndex = cards.length;
+        bookmarkEditModal.classList.remove('hidden');
+        bookmarkEditModal.classList.add('flex', 'show');
+      }
+
+      async function saveCreateModal() {
+        const type = addTypeSelect.value;
+        const title = bookmarkTitleInput.value.trim() || '未命名';
+        const url = bookmarkUrlInput.value.trim();
+        const filename = filenameInput.value.trim() || 'note.md';
+        const text = bookmarkTextarea.value;
+        const tags = bookmarkTagsInput.value.trim().split(/\s+/).filter(Boolean);
+        const height = Math.max(120, parseInt(bookmarkHeightInput.value) || 260);
+        bookmarkEditModal.classList.add('hidden');
+        bookmarkEditModal.classList.remove('flex', 'show');
+        if (type === 'mark') {
+          const marks = parseMarks(text);
+          cards.push({ type: 'webMark', title, marks, tags, height });
+        } else if (type === 'gist' || saveToGistCheck.checked) {
+          const token = localStorage.getItem('githubToken');
+          if (!token) {
+            alert('请在管理页面填写 GitHub Token');
+            return;
+          }
+          try {
+            const res = await fetch('https://api.github.com/gists', {
+              method: 'POST',
+              headers: {
+                Authorization: 'token ' + token,
+                'Content-Type': 'application/json'
+              },
+              body: JSON.stringify({
+                description: 'flow-gist',
+                public: false,
+                files: { [filename]: { content: text } }
+              })
+            });
+            if (!res.ok) throw new Error('create');
+            const data = await res.json();
+            const gistUrl = data.html_url + '?file=' + encodeURIComponent(filename);
+            const fm = parseFrontMatter(text);
+            if (fm) {
+              cards.push({
+                title: fm.title || title,
+                description: fm.description || '',
+                url: gistUrl,
+                tags: fm.tags.length ? fm.tags : ['gist'],
+                content: fm.content.trim(),
+                gistId: data.id,
+                filename
+              });
+            } else {
+              cards.push({
+                title,
+                description: '',
+                url: gistUrl,
+                tags: ['gist'],
+                content: text.trim(),
+                gistId: data.id,
+                filename
+              });
+            }
+          } catch (e) {
+            alert('创建失败');
+            console.error(e);
+          }
+        } else {
+          cards.push({ title, description: text, url, tags, height });
+        }
+        save();
+        updateTagsAndRender();
       }
 
       function showArticle(content) {
@@ -730,9 +827,9 @@
           console.error('preload', e);
         }
       }
-      addCardBtn.addEventListener('click', handleCreate);
-      newGistBtn.addEventListener('click', handleCreateGist);
-      newMarkBtn.addEventListener('click', handleCreateMark);
+      addCardBtn.addEventListener('click', () => openCreateModal('default'));
+      newGistBtn.addEventListener('click', () => openCreateModal('gist'));
+      newMarkBtn.addEventListener('click', () => openCreateModal('mark'));
       loadGistsBtn.addEventListener('click', () => {
         preloadInject();
         fetchGists();
@@ -740,7 +837,7 @@
       if (sidebarAddBtn) {
         sidebarAddBtn.addEventListener('click', (e) => {
           e.preventDefault();
-          handleCreate();
+          openCreateModal('default');
         });
       }
       tagList.addEventListener('click', (e) => {
@@ -787,7 +884,7 @@
         bookmarkEditModal.classList.remove('flex', 'show');
       });
       saveEditGist.addEventListener('click', saveEdit);
-      saveEditBookmark.addEventListener('click', saveMark);
+      saveEditBookmark.addEventListener('click', saveCreateModal);
       deleteGistBtn.addEventListener('click', deleteGist);
       // 点击遮罩层时不再关闭编辑弹窗，避免误触
       // gistEditModal.addEventListener('click', e => {


### PR DESCRIPTION
## Summary
- update `/add` creation modal to include type select and gist switch
- add unified handlers `openCreateModal` and `saveCreateModal`
- hook sidebar and buttons to new modal

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6862659c2024832ebc02f174a8fc1e3b