### PR TITLE
Add tabbed UI to settings panel

### DIFF
--- a/static/common.css
+++ b/static/common.css
@@ -307,3 +307,17 @@
       outline: none;
       box-shadow: none;
     }
+
+    /* 设置面板标签样式 */
+    #settingsTabs .tab-button {
+      border-radius: 9999px 9999px 0 0;
+      padding: 0.25rem 0.75rem;
+      font-weight: 600;
+      background-color: rgb(var(--surface));
+      color: rgb(var(--on-surface));
+    }
+
+    #settingsTabs .tab-button.active {
+      background-color: rgb(var(--primary));
+      color: #fff;
+    }

--- a/static/common.js
+++ b/static/common.js
@@ -64,11 +64,39 @@ function setupSplash() {
   });
 }
 
+function initSettingsTabs() {
+  const panel = document.getElementById('settingsPanel');
+  if (!panel) return;
+  const tabs = panel.querySelectorAll('#settingsTabs .tab-button');
+  const contents = panel.querySelectorAll('.tab-content');
+  const logList = document.getElementById('logList');
+  if (logList) {
+    const origLog = console.log.bind(console);
+    console.log = (...args) => {
+      origLog(...args);
+      const li = document.createElement('li');
+      li.textContent = args.join(' ');
+      logList.appendChild(li);
+    };
+  }
+  tabs.forEach(btn => {
+    btn.addEventListener('click', () => {
+      tabs.forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+      const target = btn.dataset.tab + 'Content';
+      contents.forEach(c => {
+        c.classList.toggle('hidden', c.id !== target);
+      });
+    });
+  });
+}
+
 window.commonReady = new Promise(resolve => {
   document.addEventListener('DOMContentLoaded', async () => {
     await includeHTML();
     initDarkMode();
     setupSplash();
+    initSettingsTabs();
     resolve();
   });
 });

--- a/static/settings.html
+++ b/static/settings.html
@@ -1,11 +1,17 @@
     <div id="settingsPanel" class="fixed inset-0 bg-black/50 hidden items-center justify-center z-50">
       <div class="bg-card rounded-xl p-4 w-72 space-y-3">
         <div class="flex justify-between items-center">
-          <h2 class="font-semibold">设置</h2>
+          <div id="settingsTabs" class="flex space-x-2">
+            <button data-tab="settings" class="tab-button active">设置</button>
+            <button data-tab="about" class="tab-button">关于</button>
+            <button data-tab="logs" class="tab-button">日志</button>
+          </div>
           <button id="closeSettings" class="text-xl leading-none">
             &times;
           </button>
         </div>
+
+        <div id="settingsContent" class="tab-content space-y-3">
 
         <!-- 深色模式切换器 -->
         <div class="flex items-center justify-between py-1">
@@ -49,5 +55,15 @@
         <footer class="text-xs text-center text-gray-400 my-4 dark:text-gray-300">
           <a href="https://github.com/valetzx/flow-wx" class="hover:underline">查看项目源码 </a> · <a href="#">联系我吧</a>
         </footer>
+        </div>
+
+        <div id="aboutContent" class="tab-content hidden text-sm">
+          <p>本项目用于展示微信公众号文章的瀑布流图集。</p>
+        </div>
+
+        <div id="logsContent" class="tab-content hidden text-sm">
+          <ul id="logList" class="space-y-1"></ul>
+        </div>
+
       </div>
     </div>


### PR DESCRIPTION
## Summary
- enhance settings panel with tabs for 设置/关于/日志
- style tabs with rounded "ear" look
- enable tab switching via common.js
- capture console logs to display in 日志 tab

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68627b938acc832e91c97fb3d4cd858e