### PR TITLE
Add about page message and button animations

### DIFF
--- a/static/common.css
+++ b/static/common.css
@@ -334,3 +334,36 @@
 #tabLogs:checked ~ #tabLogsContent {
   display: block;
 }
+
+/* About page animations */
+.about-message {
+  margin-top: 0.5rem;
+  animation: fadeInUp 0.6s ease;
+}
+
+.about-links a {
+  transition: transform 0.3s;
+}
+
+.about-links a:hover {
+  transform: scale(1.1) rotate(5deg);
+}
+
+#moreBtn {
+  transition: transform 0.3s;
+}
+
+#moreBtn:hover {
+  transform: rotate(20deg);
+}
+
+@keyframes fadeInUp {
+  from {
+    transform: translateY(10px);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}

--- a/static/common.css
+++ b/static/common.css
@@ -353,8 +353,8 @@
   transition: transform 0.3s;
 }
 
-#moreBtn:hover {
-  transform: rotate(20deg);
+#moreBtn:hover svg {
+  animation: spin 0.6s linear;
 }
 
 @keyframes fadeInUp {

--- a/static/settings.html
+++ b/static/settings.html
@@ -52,7 +52,7 @@
         <button id="clearCache" class="w-full bg-red-500 text-white py-1 rounded">清理缓存</button>
       </div>
       <div id="tabAboutContent" class="tab-content text-center text-sm">
-<div class="flex justify-between gap-2 mb-2">
+<div class="about-links flex justify-between gap-2 mb-2">
   <a href="https://github.com/valetzx" class="flex-1 bg-primary text-white py-2.5 px-2 rounded-lg flex items-center justify-center gap-2">
     <svg width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
       <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z"></path>
@@ -85,6 +85,7 @@
     </svg>
   </a>
 </div>
+<p class="about-message">不是计算机专业，但是有趣的东西都想看看。</p>
       </div>
       <div id="tabLogsContent" class="tab-content">
         <pre id="logOutput" class="text-xs whitespace-pre-wrap"></pre>


### PR DESCRIPTION
## Summary
- update settings about page to mention curiosity about tech
- animate about page text
- add hover animations for about links and settings button

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6863d1c7b608832eb6e41fc6a38abb7d