### PR TITLE
Add about note and animations

### DIFF
--- a/static/common.css
+++ b/static/common.css
@@ -334,3 +334,24 @@
 #tabLogs:checked ~ #tabLogsContent {
   display: block;
 }
+
+/* About note animation */
+#aboutNote {
+  animation: fadeInUp 0.6s ease-out;
+}
+
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* More button hover animation */
+#moreBtn:hover svg {
+  animation: spin 0.6s linear;
+}

--- a/static/settings.html
+++ b/static/settings.html
@@ -51,7 +51,7 @@
         <button id="applySettings" class="w-full bg-primary text-white py-1 rounded">应用</button>
         <button id="clearCache" class="w-full bg-red-500 text-white py-1 rounded">清理缓存</button>
       </div>
-      <div id="tabAboutContent" class="tab-content text-center text-sm">
+  <div id="tabAboutContent" class="tab-content text-center text-sm">
 <div class="flex justify-between gap-2 mb-2">
   <a href="https://github.com/valetzx" class="flex-1 bg-primary text-white py-2.5 px-2 rounded-lg flex items-center justify-center gap-2">
     <svg width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
@@ -85,6 +85,7 @@
     </svg>
   </a>
 </div>
+        <p id="aboutNote" class="mt-2">不是计算机专业，但是有趣的东西都想看看。</p>
       </div>
       <div id="tabLogsContent" class="tab-content">
         <pre id="logOutput" class="text-xs whitespace-pre-wrap"></pre>


### PR DESCRIPTION
## Summary
- enhance About tab with a personal note
- animate text appearance
- spin the settings button on hover

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6863d1c7b608832eb6e41fc6a38abb7d