### PR TITLE
Add article table of contents

### DIFF
--- a/ideas.html
+++ b/ideas.html
@@ -252,6 +252,26 @@ document.addEventListener('DOMContentLoaded', () => {
         }
       }
 
+      function buildToc(container) {
+        const headings = container.querySelectorAll('h1,h2,h3,h4,h5,h6');
+        if (headings.length < 2) return;
+        const nav = document.createElement('nav');
+        nav.className = 'toc';
+        const ul = document.createElement('ul');
+        headings.forEach((h, i) => {
+          if (!h.id) h.id = 'heading-' + i;
+          const li = document.createElement('li');
+          li.style.marginLeft = (parseInt(h.tagName[1]) - 1) * 8 + 'px';
+          const a = document.createElement('a');
+          a.href = '#' + h.id;
+          a.textContent = h.textContent.trim();
+          li.appendChild(a);
+          ul.appendChild(li);
+        });
+        nav.appendChild(ul);
+        container.prepend(nav);
+      }
+
       function showArticle(html) {
         articleContent.innerHTML = html;
         articleModal.classList.remove("hidden");
@@ -259,6 +279,7 @@ document.addEventListener('DOMContentLoaded', () => {
         // 添加深色模式样式类到文章内容
         const content = document.getElementById('articleContent');
         content.classList.add('dark:prose-invert');
+        buildToc(content);
       }
 
       function showLoading() {

--- a/static/ideas.css
+++ b/static/ideas.css
@@ -98,3 +98,10 @@
   margin-left: 0.5rem;
   border-color: rgb(var(--primary));
 }
+
+/* Table of contents */
+.toc{margin-bottom:1rem;}
+.toc ul{list-style:none;padding-left:0;}
+.toc li{margin-bottom:0.25rem;}
+.toc a{color:rgb(var(--primary));text-decoration:none;}
+.toc a:hover{text-decoration:underline;}


### PR DESCRIPTION
## Summary
- support building a table of contents for articles displayed in the modal
- style the table of contents

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_686b29fa4e2c8327a24e773be523f856