### PR TITLE
Add article table of contents

### DIFF
--- a/ideas.html
+++ b/ideas.html
@@ -46,12 +46,14 @@
     <!-- 设置面板 -->
     <div data-include="settings.html"></div>
     <div id="articleModal" class="fixed inset-0 bg-black/50 hidden items-center justify-center z-50">
-            <div class="bg-card text-on-surface rounded-xl w-11/12 max-w-3xl h-[80vh] overflow-auto relative p-4 flex">
-          <button id="closeArticle" class="absolute top-2 right-4 text-2xl">
-            &times;
-          </button>
-          <div id="articleContent" class="prose max-w-none flex-1 overflow-y-auto"></div>
-          <aside id="toc" class="hidden md:block w-1/4 ml-4 overflow-y-auto text-sm"></aside>
+      <div class="w-11/12 max-w-4xl h-[80vh] relative flex gap-4">
+        <button id="closeArticle" class="absolute top-2 right-4 text-2xl">
+          &times;
+        </button>
+        <div class="modal-panel flex-1 overflow-hidden">
+          <div id="articleContent" class="prose max-w-none h-full overflow-y-auto"></div>
+        </div>
+        <aside id="toc" class="modal-panel hidden md:block w-1/4 overflow-y-auto text-sm"></aside>
       </div>
     </div>
     <div id="toastContainer"></div>

--- a/ideas.html
+++ b/ideas.html
@@ -46,10 +46,12 @@
     <!-- 设置面板 -->
     <div data-include="settings.html"></div>
     <div id="articleModal" class="fixed inset-0 bg-black/50 hidden items-center justify-center z-50">
-            <div class="bg-card text-on-surface rounded-xl w-11/12 max-w-3xl h-[80vh] overflow-auto relative p-4"> <button id="closeArticle" class="absolute top-2 right-4 text-2xl">
+            <div class="bg-card text-on-surface rounded-xl w-11/12 max-w-3xl h-[80vh] overflow-auto relative p-4 flex">
+          <button id="closeArticle" class="absolute top-2 right-4 text-2xl">
             &times;
           </button>
-        <div id="articleContent" class="prose max-w-none"></div>
+          <div id="articleContent" class="prose max-w-none flex-1 overflow-y-auto"></div>
+          <aside id="toc" class="hidden md:block w-1/4 ml-4 overflow-y-auto text-sm"></aside>
       </div>
     </div>
     <div id="toastContainer"></div>
@@ -252,8 +254,33 @@ document.addEventListener('DOMContentLoaded', () => {
         }
       }
 
+      function generateToc() {
+        const toc = document.getElementById('toc');
+        if (!toc) return;
+        toc.innerHTML = '';
+        const headings = articleContent.querySelectorAll('h1, h2, h3, h4, h5, h6');
+        if (headings.length === 0) {
+          toc.classList.add('hidden');
+          return;
+        }
+        toc.classList.remove('hidden');
+        const list = document.createElement('ul');
+        headings.forEach(h => {
+          if (!h.id) h.id = 'h-' + Math.random().toString(36).slice(2, 8);
+          const li = document.createElement('li');
+          li.className = 'pl-' + ((parseInt(h.tagName[1]) - 1) * 2);
+          const a = document.createElement('a');
+          a.href = '#' + h.id;
+          a.textContent = h.textContent;
+          li.appendChild(a);
+          list.appendChild(li);
+        });
+        toc.appendChild(list);
+      }
+
       function showArticle(html) {
         articleContent.innerHTML = html;
+        generateToc();
         articleModal.classList.remove("hidden");
         articleModal.classList.add("flex", "show");
         // 添加深色模式样式类到文章内容
@@ -312,6 +339,11 @@ document.addEventListener('DOMContentLoaded', () => {
         articleModal.classList.add("hidden");
         articleModal.classList.remove("flex", "show");
         articleContent.innerHTML = "";
+        const toc = document.getElementById('toc');
+        if (toc) {
+          toc.innerHTML = '';
+          toc.classList.add('hidden');
+        }
       }
       const savedCols = parseInt(localStorage.getItem("columnCount")) || 4;
       const savedPerPage = parseInt(localStorage.getItem("perPage")) || 30;

--- a/ideas.html
+++ b/ideas.html
@@ -51,9 +51,9 @@
           &times;
         </button>
         <div class="modal-panel flex-1 overflow-hidden">
-          <div id="articleContent" class="prose max-w-none h-full overflow-y-auto"></div>
+          <div id="articleContent" class="prose max-w-none h-full overflow-y-auto no-scrollbar"></div>
         </div>
-        <aside id="toc" class="modal-panel hidden md:block w-1/4 overflow-y-auto text-sm"></aside>
+        <aside id="toc" class="modal-panel hidden md:block w-1/4 overflow-y-auto no-scrollbar text-sm"></aside>
       </div>
     </div>
     <div id="toastContainer"></div>

--- a/static/ideas.css
+++ b/static/ideas.css
@@ -98,3 +98,25 @@
   margin-left: 0.5rem;
   border-color: rgb(var(--primary));
 }
+
+#toc ul {
+  list-style: none;
+  padding-left: 0;
+}
+
+#toc li a {
+  display: block;
+  padding: 0.25rem 0;
+  color: rgb(107, 114, 128);
+}
+
+#toc li a:hover {
+  color: rgb(var(--primary));
+}
+
+#toc {
+  border: 1px solid rgb(var(--border));
+  border-radius: 0.5rem;
+  background-color: rgb(var(--card));
+  padding: 0.5rem;
+}

--- a/static/ideas.css
+++ b/static/ideas.css
@@ -114,7 +114,8 @@
   color: rgb(var(--primary));
 }
 
-#toc {
+
+.modal-panel {
   border: 1px solid rgb(var(--border));
   border-radius: 0.5rem;
   background-color: rgb(var(--card));


### PR DESCRIPTION
## Summary
- add a TOC panel to the article modal
- generate heading links when displaying an article
- style the TOC list
- improve layout and style so the TOC sits in a standalone box on the right

## Testing
- `npm run build`
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_b_686b29fa4e2c8327a24e773be523f856