### PR TITLE
feat: load comments on add page

### DIFF
--- a/add.html
+++ b/add.html
@@ -897,8 +897,34 @@
         }
         location.reload();
       });
-      
-    hideSplash(true);
+
+      async function loadComments() {
+        const apiUrl = `https://cnbapi.haorwen.top/wss/apps/cnb-room/-/issues/3/comments?page=1&page_size=20`;
+        try {
+          const res = await fetch(apiUrl, {
+            method: 'GET',
+            headers: {
+              'accept': 'application/json',
+              'Authorization': `Bearer 0149aBDu3HiLoQiizvUq1JZb3BD`
+            }
+          });
+          if (!res.ok) throw new Error('HTTP ' + res.status);
+          const data = await res.json();
+          data.forEach(c => {
+            cards.push({
+              title: c.author?.nickname || c.author?.username || '',
+              description: c.body,
+              tags: ['评论']
+            });
+          });
+          updateTagsAndRender();
+        } catch (err) {
+          console.error('加载评论失败', err);
+        }
+      }
+
+      loadComments();
+      hideSplash(true);
     });
   });
 </script>

--- a/node.js
+++ b/node.js
@@ -38,6 +38,7 @@ function injectConfig(html) {
 
 const indexHtml = injectConfig(await fs.readFile(path.join(__dirname, 'main.html'), 'utf8'));
 const ideasHtml = injectConfig(await fs.readFile(path.join(__dirname, 'ideas.html'), 'utf8'));
+const addHtml = injectConfig(await fs.readFile(path.join(__dirname, 'add.html'), 'utf8'));
 const adminHtml = injectConfig(await fs.readFile(path.join(__dirname, 'admin.html'), 'utf8'));
 const swRaw = await fs.readFile(path.join(__dirname, 'static', 'sw.js'), 'utf8');
 const swHtml = `const IMG_CACHE = ${JSON.stringify(cacheImgDomain)};\n${swRaw}`;
@@ -493,6 +494,10 @@ app.get('/@admin', (req, res) => {
 
 app.get('/ideas', (req, res) => {
   res.type('html').send(ideasHtml);
+});
+
+app.get('/add', (req, res) => {
+  res.type('html').send(addHtml);
 });
 
 app.get('*', (req, res) => {


### PR DESCRIPTION
## Summary
- serve dedicated add page with express
- fetch comment API and render cards with nickname, body, and `评论` tag

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68adac9dfdc4832b9f134196c02dd88d