### PR TITLE
feat: add plugin system for add page

### DIFF
--- a/add.html
+++ b/add.html
@@ -130,6 +130,9 @@
       const contentEl = document.getElementById('content');
       const isMobile = /Mobi|Android|iPhone|iPad|iPod|Windows Phone/i.test(navigator.userAgent);
 
+      let plugins = [];
+      let currentPlugin = null;
+
       const savedToken = localStorage.getItem('githubToken') || '';
       if (savedToken) {
         loadGistsBtn.classList.remove('hidden');
@@ -540,6 +543,17 @@
           btn.className = 'px-3 py-1 rounded-full text-sm border-2 border-transparent hover:border-primary bg-card';
           tagList.appendChild(btn);
         });
+        plugins.forEach(p => {
+          const btn = document.createElement('button');
+          btn.dataset.tag = p.name;
+          btn.dataset.pluginUrl = '/plugin/' + p.file;
+          btn.textContent = p.name;
+          btn.className = 'px-3 py-1 rounded-full text-sm border-2 border-transparent hover:border-primary bg-card';
+          if (currentPlugin && currentPlugin.name === p.name) {
+            btn.classList.add('bg-primary', 'text-white', 'border-primary');
+          }
+          tagList.appendChild(btn);
+        });
       }
 
       function applyFilter() {
@@ -568,6 +582,50 @@
           col.appendChild(createCard(item, idx));
           rIndex++;
         });
+      }
+
+      async function renderPlugin(p) {
+        columns.forEach(col => col.innerHTML = '');
+        try {
+          const res = await fetch('/plugin/' + p.file);
+          if (!res.ok) throw new Error('HTTP ' + res.status);
+          const html = await res.text();
+          const doc = new DOMParser().parseFromString(html, 'text/html');
+          let width, height;
+          const size = doc.querySelector('meta[name="card-size"]')?.getAttribute('content');
+          if (size) {
+            const m = size.match(/(\d+)x(\d+)/);
+            if (m) {
+              width = parseInt(m[1]);
+              height = parseInt(m[2]);
+            }
+          }
+          const card = document.createElement('div');
+          card.className = 'bg-card text-on-surface rounded-lg overflow-hidden';
+          if (width) card.style.width = width + 'px';
+          if (height) card.style.height = height + 'px';
+          card.innerHTML = doc.body.innerHTML || '';
+          columns[0].appendChild(card);
+          card.querySelectorAll('script').forEach(old => {
+            const s = document.createElement('script');
+            if (old.src) s.src = old.src;
+            s.textContent = old.textContent;
+            old.replaceWith(s);
+          });
+        } catch (err) {
+          console.error('加载插件失败', err);
+        }
+      }
+
+      async function loadPlugins() {
+        try {
+          const res = await fetch('/api/plugins');
+          if (!res.ok) throw new Error('HTTP ' + res.status);
+          plugins = await res.json();
+          renderTags(collectTags());
+        } catch (err) {
+          console.error('加载插件列表失败', err);
+        }
       }
 
       function handleEditMark(index) {
@@ -839,10 +897,21 @@
           openCreateModal();
         });
       }
-      tagList.addEventListener('click', (e) => {
+      tagList.addEventListener('click', async (e) => {
         const btn = e.target.closest('button[data-tag]');
         if (!btn) return;
+        const pluginUrl = btn.dataset.pluginUrl;
         const tag = btn.dataset.tag;
+        if (pluginUrl) {
+          currentPlugin = plugins.find(p => '/plugin/' + p.file === pluginUrl) || null;
+          if (currentPlugin) await renderPlugin(currentPlugin);
+          selectedTags = [];
+          Array.from(tagList.querySelectorAll('button[data-tag]')).forEach(b => b.classList.remove('bg-primary', 'text-white', 'border-primary'));
+          btn.classList.add('bg-primary', 'text-white', 'border-primary');
+          return;
+        }
+        currentPlugin = null;
+        Array.from(tagList.querySelectorAll('button[data-plugin-url]')).forEach(b => b.classList.remove('bg-primary', 'text-white', 'border-primary'));
         if (!tag) return;
         if (allowMultiTags) {
           if (selectedTags.includes(tag)) {
@@ -969,6 +1038,7 @@
       }
 
       loadComments();
+      loadPlugins();
       hideSplash(true);
     });
   });

--- a/node.js
+++ b/node.js
@@ -24,6 +24,27 @@ app.use((req, res, next) => {
 // Serve files from the static directory
 app.use(express.static(path.join(__dirname, 'static')));
 
+// Serve plugin files
+const pluginDir = path.join(__dirname, 'plugin');
+app.use('/plugin', express.static(pluginDir));
+
+app.get('/api/plugins', async (_req, res) => {
+  try {
+    const files = await fs.readdir(pluginDir);
+    const plugins = [];
+    for (const file of files) {
+      if (!file.endsWith('.html')) continue;
+      const html = await fs.readFile(path.join(pluginDir, file), 'utf8');
+      const $ = cheerio.load(html);
+      const title = $('title').text().trim() || file.replace(/\.html$/, '');
+      plugins.push({ name: title, file });
+    }
+    res.json(plugins);
+  } catch {
+    res.json([]);
+  }
+});
+
 const apiDomains = (process.env.API_DOMAINS || '').split(/[\s,]+/).filter(Boolean);
 const imgDomains = (process.env.IMG_DOMAINS || '').split(/[\s,]+/).filter(Boolean);
 const cacheImgDomain = process.env.IMG_CACHE || '';

--- a/plugin/calculator.html
+++ b/plugin/calculator.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8" />
+  <title>计算器</title>
+  <meta name="card-size" content="300x260">
+  <style>
+    :root {
+      color-scheme: light dark;
+    }
+    body {
+      margin: 0;
+      background: transparent;
+      color: rgb(var(--on-surface));
+      font-family: ui-sans-serif, system-ui;
+    }
+    input {
+      width: 100%;
+      padding: 4px;
+      margin-bottom: 4px;
+      background: rgb(var(--card));
+      border: 1px solid rgb(var(--border));
+      border-radius: 4px;
+      color: rgb(var(--on-surface));
+    }
+    button {
+      width: 100%;
+      padding: 6px;
+      background: rgb(var(--primary));
+      color: #fff;
+      border: none;
+      border-radius: 4px;
+    }
+  </style>
+</head>
+<body>
+  <div id="calculator" class="p-2">
+    <input id="num1" type="number" placeholder="数字1" />
+    <input id="num2" type="number" placeholder="数字2" />
+    <button id="calcBtn">相加</button>
+    <div id="result" class="mt-2"></div>
+  </div>
+  <script>
+    document.getElementById('calcBtn').addEventListener('click', () => {
+      const a = parseFloat(document.getElementById('num1').value) || 0;
+      const b = parseFloat(document.getElementById('num2').value) || 0;
+      document.getElementById('result').textContent = a + b;
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- serve plugin directory and expose `/api/plugins` to list plugin HTML titles
- load plugin tabs on /add by parsing titles and rendering selected plugin HTML as cards
- add calculator plugin template supporting theme and custom card size

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68b110321440832b95739d70e2248a2f