### PR TITLE
feat(plugin): support default display on add

### DIFF
--- a/add.html
+++ b/add.html
@@ -622,7 +622,9 @@
           const res = await fetch('/api/plugins');
           if (!res.ok) throw new Error('HTTP ' + res.status);
           plugins = await res.json();
+          currentPlugin = plugins.find(p => p.show) || null;
           renderTags(collectTags());
+          if (currentPlugin) await renderPlugin(currentPlugin);
         } catch (err) {
           console.error('加载插件列表失败', err);
         }

--- a/build.js
+++ b/build.js
@@ -185,7 +185,8 @@ try {
     const html = await fs.readFile(src, 'utf8');
     const $ = cheerio.load(html);
     const title = $('title').text().trim() || file.replace(/\.html$/, '');
-    pluginList.push({ name: title, file });
+    const show = $('meta[name="show"]').attr('content') === '1';
+    pluginList.push({ name: title, file, show });
   }
 } catch {}
 await fs.writeFile(

--- a/node.js
+++ b/node.js
@@ -37,7 +37,8 @@ app.get('/api/plugins', async (_req, res) => {
       const html = await fs.readFile(path.join(pluginDir, file), 'utf8');
       const $ = cheerio.load(html);
       const title = $('title').text().trim() || file.replace(/\.html$/, '');
-      plugins.push({ name: title, file });
+      const show = $('meta[name="show"]').attr('content') === '1';
+      plugins.push({ name: title, file, show });
     }
     res.json(plugins);
   } catch {

--- a/plugin/calculator.html
+++ b/plugin/calculator.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <title>计算器</title>
   <meta name="card-size" content="300x260">
+  <meta name="show" content="1">
   <link rel="stylesheet" href="../common.css" />
   <style>
     body { background: rgb(var(--card)); color: rgb(var(--on-surface)); font-family: sans-serif; }

--- a/plugin/calculator.html
+++ b/plugin/calculator.html
@@ -7,10 +7,50 @@
   <meta name="show" content="1">
   <link rel="stylesheet" href="../common.css" />
   <style>
-    body { background: rgb(var(--card)); color: rgb(var(--on-surface)); font-family: sans-serif; }
-    #calc { display: grid; grid-template-columns: repeat(4, 1fr); gap: 0.25rem; }
-    #calc button { padding: 0.5rem; background: rgb(var(--primary)); color: white; border: none; border-radius: 0.25rem; }
-    #calc input { grid-column: span 4; margin-bottom: 0.25rem; padding: 0.5rem; background: rgb(var(--surface)); color: rgb(var(--on-surface)); border: 1px solid rgb(var(--border)); border-radius: 0.25rem; }
+    body {
+      background: rgb(var(--card));
+      color: rgb(var(--on-surface));
+      font-family: sans-serif;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      height: 100%;
+      margin: 0;
+    }
+    #calc {
+      display: grid;
+      grid-template-columns: repeat(4, 3rem);
+      gap: 0.5rem;
+      background: rgb(var(--surface));
+      padding: 0.5rem;
+      border-radius: 0.5rem;
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    }
+    #calc button {
+      padding: 0.5rem;
+      font-size: 1.25rem;
+      background: rgb(var(--surface));
+      color: rgb(var(--on-surface));
+      border: none;
+      border-radius: 0.25rem;
+      cursor: pointer;
+      transition: filter 0.1s;
+      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+    }
+    #calc button.operator { background: rgb(var(--primary)); color: #fff; }
+    #calc button.control { background: rgb(var(--secondary)); color: #fff; }
+    #calc button:active { filter: brightness(0.9); }
+    #calc input {
+      grid-column: 1 / -1;
+      margin-bottom: 0.5rem;
+      padding: 0.5rem;
+      background: rgb(var(--card));
+      color: rgb(var(--on-surface));
+      border: 1px solid rgb(var(--border));
+      border-radius: 0.25rem;
+      font-size: 1.5rem;
+      text-align: right;
+    }
   </style>
 </head>
 <body class="p-2">
@@ -20,19 +60,19 @@
     <button data-v="7">7</button>
     <button data-v="8">8</button>
     <button data-v="9">9</button>
-    <button data-op="/">÷</button>
+    <button data-op="/" class="operator">÷</button>
     <button data-v="4">4</button>
     <button data-v="5">5</button>
     <button data-v="6">6</button>
-    <button data-op="*">×</button>
+    <button data-op="*" class="operator">×</button>
     <button data-v="1">1</button>
     <button data-v="2">2</button>
     <button data-v="3">3</button>
-    <button data-op="-">-</button>
+    <button data-op="-" class="operator">-</button>
     <button data-v="0">0</button>
-    <button id="clear">C</button>
-    <button id="equals">=</button>
-    <button data-op="+">+</button>
+    <button id="clear" class="control">C</button>
+    <button id="equals" class="control">=</button>
+    <button data-op="+" class="operator">+</button>
   </div>
   <script>
     const display = document.getElementById('display');

--- a/server.ts
+++ b/server.ts
@@ -558,13 +558,14 @@ async function handler(req: Request): Promise<Response> {
 
   if (pathname === "/api/plugins") {
     try {
-      const plugins: { name: string; file: string }[] = [];
+      const plugins: { name: string; file: string; show: boolean }[] = [];
       for await (const entry of Deno.readDir(pluginDir)) {
         if (!entry.isFile || !entry.name.endsWith(".html")) continue;
         const html = await Deno.readTextFile(join(pluginDir, entry.name));
         const $ = cheerio.load(html);
         const title = $("title").text().trim() || entry.name.replace(/\.html$/, "");
-        plugins.push({ name: title, file: entry.name });
+        const show = $("meta[name='show']").attr("content") === "1";
+        plugins.push({ name: title, file: entry.name, show });
       }
       return json(plugins);
     } catch {

--- a/worker.js
+++ b/worker.js
@@ -61,7 +61,8 @@ const pluginFiles = {
 const plugins = Object.entries(pluginFiles).map(([file, html]) => {
   const $ = cheerio.load(html);
   const name = $("title").text().trim() || file.replace(/\.html$/, "");
-  return { name, file, content: html };
+  const show = $("meta[name='show']").attr("content") === "1";
+  return { name, file, content: html, show };
 });
 
 function parseArticles(text) {
@@ -676,7 +677,7 @@ async function cacheThenNetwork(request) {
 
     if (pathname === "/api/plugins") {
       return new Response(
-        JSON.stringify(plugins.map(p => ({ name: p.name, file: p.file }))),
+        JSON.stringify(plugins.map(p => ({ name: p.name, file: p.file, show: p.show }))),
         {
           headers: withCors({ "Content-Type": "application/json; charset=utf-8" }),
         },


### PR DESCRIPTION
## Summary
- allow plugins to declare `<meta name="show">` to be automatically rendered on `/add`
- expose `show` flag through plugin APIs and build pipeline
- demo calculator plugin configured to show by default

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b11a31129c832b8bd85e71c73ed43f