### PR TITLE
feat: allow default plugin display

### DIFF
--- a/add.html
+++ b/add.html
@@ -623,6 +623,13 @@
           if (!res.ok) throw new Error('HTTP ' + res.status);
           plugins = await res.json();
           renderTags(collectTags());
+          const defaultPlugin = plugins.find(p => p.show);
+          if (defaultPlugin) {
+            currentPlugin = defaultPlugin;
+            await renderPlugin(defaultPlugin);
+            const btn = tagList.querySelector(`button[data-plugin-url='/plugin/${defaultPlugin.file}']`);
+            if (btn) btn.classList.add('bg-primary', 'text-white', 'border-primary');
+          }
         } catch (err) {
           console.error('加载插件列表失败', err);
         }

--- a/build.js
+++ b/build.js
@@ -185,7 +185,8 @@ try {
     const html = await fs.readFile(src, 'utf8');
     const $ = cheerio.load(html);
     const title = $('title').text().trim() || file.replace(/\.html$/, '');
-    pluginList.push({ name: title, file });
+    const show = $('meta[name="show"]').attr('content') === '1';
+    pluginList.push({ name: title, file, show });
   }
 } catch {}
 await fs.writeFile(

--- a/node.js
+++ b/node.js
@@ -37,7 +37,8 @@ app.get('/api/plugins', async (_req, res) => {
       const html = await fs.readFile(path.join(pluginDir, file), 'utf8');
       const $ = cheerio.load(html);
       const title = $('title').text().trim() || file.replace(/\.html$/, '');
-      plugins.push({ name: title, file });
+      const show = $('meta[name="show"]').attr('content') === '1';
+      plugins.push({ name: title, file, show });
     }
     res.json(plugins);
   } catch {

--- a/plugin/calculator.html
+++ b/plugin/calculator.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <title>计算器</title>
   <meta name="card-size" content="300x260">
+  <meta name="show" content="1">
   <link rel="stylesheet" href="../common.css" />
   <style>
     body { background: rgb(var(--card)); color: rgb(var(--on-surface)); font-family: sans-serif; }

--- a/server.ts
+++ b/server.ts
@@ -558,13 +558,14 @@ async function handler(req: Request): Promise<Response> {
 
   if (pathname === "/api/plugins") {
     try {
-      const plugins: { name: string; file: string }[] = [];
+      const plugins: { name: string; file: string; show?: boolean }[] = [];
       for await (const entry of Deno.readDir(pluginDir)) {
         if (!entry.isFile || !entry.name.endsWith(".html")) continue;
         const html = await Deno.readTextFile(join(pluginDir, entry.name));
         const $ = cheerio.load(html);
         const title = $("title").text().trim() || entry.name.replace(/\.html$/, "");
-        plugins.push({ name: title, file: entry.name });
+        const show = $("meta[name='show']").attr("content") === "1";
+        plugins.push({ name: title, file: entry.name, show });
       }
       return json(plugins);
     } catch {

--- a/worker.js
+++ b/worker.js
@@ -61,7 +61,8 @@ const pluginFiles = {
 const plugins = Object.entries(pluginFiles).map(([file, html]) => {
   const $ = cheerio.load(html);
   const name = $("title").text().trim() || file.replace(/\.html$/, "");
-  return { name, file, content: html };
+  const show = $("meta[name='show']").attr("content") === "1";
+  return { name, file, show, content: html };
 });
 
 function parseArticles(text) {
@@ -676,7 +677,7 @@ async function cacheThenNetwork(request) {
 
     if (pathname === "/api/plugins") {
       return new Response(
-        JSON.stringify(plugins.map(p => ({ name: p.name, file: p.file }))),
+        JSON.stringify(plugins.map(p => ({ name: p.name, file: p.file, show: p.show }))),
         {
           headers: withCors({ "Content-Type": "application/json; charset=utf-8" }),
         },


### PR DESCRIPTION
## Summary
- add `show` meta in plugin HTML to mark default plugin
- propagate `show` flag through build, server, worker, and API responses
- auto render default plugin on `/add` page when flag is set

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b1331bc9c0832bb41905232f36ea04