### PR TITLE
feat: support default plugin cards

### DIFF
--- a/add.html
+++ b/add.html
@@ -582,6 +582,24 @@
           col.appendChild(createCard(item, idx));
           rIndex++;
         });
+        if (selectedTags.length === 0 && !currentPlugin) {
+          plugins.filter(p => p.show && p.cardHtml).forEach(p => {
+            const card = document.createElement('div');
+            card.className = 'bg-card text-on-surface rounded-lg overflow-hidden';
+            if (p.width) card.style.width = p.width + 'px';
+            if (p.height) card.style.height = p.height + 'px';
+            card.innerHTML = p.cardHtml;
+            const col = columns[rIndex % columns.length];
+            col.appendChild(card);
+            card.querySelectorAll('script').forEach(old => {
+              const s = document.createElement('script');
+              if (old.src) s.src = old.src;
+              s.textContent = old.textContent;
+              old.replaceWith(s);
+            });
+            rIndex++;
+          });
+        }
       }
 
       async function renderPlugin(p) {
@@ -622,7 +640,29 @@
           const res = await fetch('/api/plugins');
           if (!res.ok) throw new Error('HTTP ' + res.status);
           plugins = await res.json();
+          for (const p of plugins) {
+            if (p.show) {
+              try {
+                const r = await fetch('/plugin/' + p.file);
+                if (!r.ok) throw new Error('HTTP ' + r.status);
+                const html = await r.text();
+                const doc = new DOMParser().parseFromString(html, 'text/html');
+                const size = doc.querySelector('meta[name="card-size"]')?.getAttribute('content');
+                if (size) {
+                  const m = size.match(/(\d+)x(\d+)/);
+                  if (m) {
+                    p.width = parseInt(m[1]);
+                    p.height = parseInt(m[2]);
+                  }
+                }
+                p.cardHtml = doc.body.innerHTML || '';
+              } catch (e) {
+                console.error('加载插件失败', p.file, e);
+              }
+            }
+          }
           renderTags(collectTags());
+          applyFilter();
         } catch (err) {
           console.error('加载插件列表失败', err);
         }

--- a/build.js
+++ b/build.js
@@ -185,7 +185,8 @@ try {
     const html = await fs.readFile(src, 'utf8');
     const $ = cheerio.load(html);
     const title = $('title').text().trim() || file.replace(/\.html$/, '');
-    pluginList.push({ name: title, file });
+    const show = $('meta[name="show"]').attr('content') === '1';
+    pluginList.push({ name: title, file, show });
   }
 } catch {}
 await fs.writeFile(

--- a/node.js
+++ b/node.js
@@ -37,7 +37,8 @@ app.get('/api/plugins', async (_req, res) => {
       const html = await fs.readFile(path.join(pluginDir, file), 'utf8');
       const $ = cheerio.load(html);
       const title = $('title').text().trim() || file.replace(/\.html$/, '');
-      plugins.push({ name: title, file });
+      const show = $('meta[name="show"]').attr('content') === '1';
+      plugins.push({ name: title, file, show });
     }
     res.json(plugins);
   } catch {

--- a/plugin/calculator.html
+++ b/plugin/calculator.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <title>计算器</title>
   <meta name="card-size" content="300x260">
+  <meta name="show" content="1">
   <link rel="stylesheet" href="../common.css" />
   <style>
     body { background: rgb(var(--card)); color: rgb(var(--on-surface)); font-family: sans-serif; }

--- a/server.ts
+++ b/server.ts
@@ -558,13 +558,14 @@ async function handler(req: Request): Promise<Response> {
 
   if (pathname === "/api/plugins") {
     try {
-      const plugins: { name: string; file: string }[] = [];
+      const plugins: { name: string; file: string; show?: boolean }[] = [];
       for await (const entry of Deno.readDir(pluginDir)) {
         if (!entry.isFile || !entry.name.endsWith(".html")) continue;
         const html = await Deno.readTextFile(join(pluginDir, entry.name));
         const $ = cheerio.load(html);
         const title = $("title").text().trim() || entry.name.replace(/\.html$/, "");
-        plugins.push({ name: title, file: entry.name });
+        const show = $("meta[name='show']").attr("content") === "1";
+        plugins.push({ name: title, file: entry.name, show });
       }
       return json(plugins);
     } catch {

--- a/worker.js
+++ b/worker.js
@@ -61,7 +61,8 @@ const pluginFiles = {
 const plugins = Object.entries(pluginFiles).map(([file, html]) => {
   const $ = cheerio.load(html);
   const name = $("title").text().trim() || file.replace(/\.html$/, "");
-  return { name, file, content: html };
+  const show = $("meta[name='show']").attr("content") === "1";
+  return { name, file, content: html, show };
 });
 
 function parseArticles(text) {
@@ -676,7 +677,7 @@ async function cacheThenNetwork(request) {
 
     if (pathname === "/api/plugins") {
       return new Response(
-        JSON.stringify(plugins.map(p => ({ name: p.name, file: p.file }))),
+        JSON.stringify(plugins.map(p => ({ name: p.name, file: p.file, show: p.show }))),
         {
           headers: withCors({ "Content-Type": "application/json; charset=utf-8" }),
         },


### PR DESCRIPTION
## Summary
- allow plugins to mark themselves for default display with `<meta name="show" content="1">`
- expose `show` flag in plugin API on server, build script and worker
- preload and render `show`ed plugins on `/add` page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b1331bc9c0832bb41905232f36ea04