### PR TITLE
feat: enable desktop drag for tag list

### DIFF
--- a/add.html
+++ b/add.html
@@ -37,7 +37,7 @@
     <header class="py-2 text-center">
       <button id="addCardBtn" class="px-4 py-2 bg-primary text-white rounded hidden">新增卡片</button>
     </header>
-    <div id="tagList" class="flex overflow-x-auto whitespace-nowrap gap-2 px-4 mb-4 no-scrollbar w-full">
+    <div id="tagList" class="flex overflow-x-auto whitespace-nowrap gap-2 px-4 mb-4 no-scrollbar w-full cursor-grab active:cursor-grabbing select-none">
       <button id="loadGistsBtn" class="px-3 py-1 rounded-full text-sm border-2 border-transparent hover:border-primary bg-card hidden"> ↻ </button>
       <button id="newMarkBtn" class="px-3 py-1 rounded-full text-sm border-2 border-transparent hover:border-primary bg-card hidden"> ☆ </button>
     </div>

--- a/ideas.html
+++ b/ideas.html
@@ -37,7 +37,7 @@
   <div data-include="sidebar.html"></div>
   <div id="content" class="ml-[72px]">
     <header class="py-2 text-center"> </header>
-    <div id="tagList" class="flex overflow-x-auto whitespace-nowrap gap-2 px-4 mb-4 no-scrollbar w-full"></div>
+    <div id="tagList" class="flex overflow-x-auto whitespace-nowrap gap-2 px-4 mb-4 no-scrollbar w-full cursor-grab active:cursor-grabbing select-none"></div>
     <main class="px-4 pb-8 w-full">
       <!-- Masonry 容器 -->
       <div class="masonry" id="gallery"></div> <button id="loadMore" class="mt-4 mx-auto block px-4 py-2 rounded bg-gray-200 text-gray-700 hidden">

--- a/main.html
+++ b/main.html
@@ -39,7 +39,7 @@
     <header class="py-2 text-center">
       <h2 class="text-1xl font-bold tracking-tight text-on-surface"></h2>
     </header>
-    <div id="tagList" class="flex overflow-x-auto whitespace-nowrap gap-2 px-4 mb-4 no-scrollbar w-full"></div>
+    <div id="tagList" class="flex overflow-x-auto whitespace-nowrap gap-2 px-4 mb-4 no-scrollbar w-full cursor-grab active:cursor-grabbing select-none"></div>
 
     <main class="px-4 pb-8 w-full">
       <!-- Masonry 容器 -->

--- a/static/common.js
+++ b/static/common.js
@@ -64,11 +64,42 @@ function setupSplash() {
   });
 }
 
+function setupTagListDrag() {
+  const tagList = document.getElementById('tagList');
+  if (!tagList) return;
+  let isDown = false;
+  let startX = 0;
+  let scrollLeft = 0;
+  tagList.addEventListener('mousedown', (e) => {
+    if (e.button !== 0) return;
+    isDown = true;
+    startX = e.pageX - tagList.offsetLeft;
+    scrollLeft = tagList.scrollLeft;
+    tagList.classList.add('cursor-grabbing');
+  });
+  tagList.addEventListener('mouseleave', () => {
+    isDown = false;
+    tagList.classList.remove('cursor-grabbing');
+  });
+  tagList.addEventListener('mouseup', () => {
+    isDown = false;
+    tagList.classList.remove('cursor-grabbing');
+  });
+  tagList.addEventListener('mousemove', (e) => {
+    if (!isDown) return;
+    e.preventDefault();
+    const x = e.pageX - tagList.offsetLeft;
+    const walk = x - startX;
+    tagList.scrollLeft = scrollLeft - walk;
+  });
+}
+
 window.commonReady = new Promise(resolve => {
   document.addEventListener('DOMContentLoaded', async () => {
     await includeHTML();
     initDarkMode();
     setupSplash();
+    setupTagListDrag();
     resolve();
   });
 });


### PR DESCRIPTION
## Summary
- allow dragging to scroll tag lists on desktop
- style tag list with grab cursor and disable selection

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68b2e00be134832b84b1ea10728397ac